### PR TITLE
Return expanded struct in `expander.produce` instead of `nil`

### DIFF
--- a/server/apps/expand.go
+++ b/server/apps/expand.go
@@ -146,7 +146,7 @@ func (e *expander) produce(expand *Expand) *Expanded {
 
 	expanded.User = produceUser(e.User, expand)
 	expanded.ActingUser = produceUser(e.ActingUser, expand)
-	return nil
+	return expanded
 }
 
 func produceUser(user *model.User, expand *Expand) *model.User {


### PR DESCRIPTION
There's a typo where we're unconditionally returning `nil` in `expander.produce`, when we should be returning the expanded struct.