### PR TITLE
Add aws client caching support

### DIFF
--- a/server/apps/api.go
+++ b/server/apps/api.go
@@ -6,6 +6,7 @@ package apps
 import (
 	"github.com/dgrijalva/jwt-go"
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
+	"github.com/mattermost/mattermost-plugin-apps/server/aws"
 	"github.com/mattermost/mattermost-plugin-apps/server/configurator"
 	"github.com/mattermost/mattermost-plugin-apps/server/utils/md"
 )
@@ -17,6 +18,7 @@ type Service struct {
 	Mattermost   *pluginapi.Client
 	API          API
 	Client       Client
+	AWSProxy     aws.Proxy
 }
 type SessionToken string
 

--- a/server/apps/impl/service.go
+++ b/server/apps/impl/service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mattermost/mattermost-plugin-apps/server/apps"
 	"github.com/mattermost/mattermost-plugin-apps/server/apps/store"
+	"github.com/mattermost/mattermost-plugin-apps/server/aws"
 	"github.com/mattermost/mattermost-plugin-apps/server/configurator"
 )
 
@@ -31,6 +32,7 @@ func NewService(mm *pluginapi.Client, configurator configurator.Service) *apps.S
 	}
 	s.Client = s.newClient()
 	s.API = s
+	s.AWSProxy = aws.NewAWSProxy(mm)
 
 	return &s.Service
 }

--- a/server/aws/client.go
+++ b/server/aws/client.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -49,8 +50,23 @@ type Service struct {
 	iam    *iam.IAM
 }
 
+// NewAWSClientWithConfigWithLogger returns a new instance of Client with a custom configuration.
+func NewAWSClientWithConfigWithLogger(config *aws.Config, logger log.FieldLogger) *Client {
+	return &Client{
+		logger: logger,
+		config: config,
+		mux:    &sync.Mutex{},
+	}
+}
+
 // NewAWSClientWithConfig returns a new instance of Client with a custom configuration.
-func NewAWSClientWithConfig(config *aws.Config, logger log.FieldLogger) *Client {
+func NewAWSClientWithConfig(config *aws.Config) *Client {
+	logger := log.New()
+	logger.SetFormatter(&log.TextFormatter{
+		FullTimestamp: true,
+	})
+	// Output to stdout instead of the default stderr.
+	logger.SetOutput(os.Stdout)
 	return &Client{
 		logger: logger,
 		config: config,

--- a/server/aws/client_cache.go
+++ b/server/aws/client_cache.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See License for license information.
+
+package aws
+
+import (
+	sdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+
+	"github.com/pkg/errors"
+)
+
+// DefaultRegion describes default region in aws
+const DefaultRegion = "us-east-2"
+
+type clientCache struct {
+	store CredentialStoreService
+	cache map[string]*Client // appID - Client
+}
+
+func newClientCache(store CredentialStoreService) (*clientCache, error) {
+	cache := make(map[string]*Client)
+	list, err := store.GetAppList()
+	if err != nil {
+		return nil, errors.Wrap(err, "can't get credentials")
+	}
+	cc := &clientCache{
+		store: store,
+		cache: cache,
+	}
+	for _, appID := range list {
+		if _, err := cc.create(appID); err != nil {
+			return nil, errors.Wrapf(err, "can't create client for app %s", appID)
+		}
+	}
+	return cc, nil
+}
+
+func (c *clientCache) create(appID string) (*Client, error) {
+	keyID, secret, err := c.store.GetAWSCredential(appID)
+	if err != nil {
+		return nil, errors.Wrap(err, "can't get app from the store")
+	}
+	var config *sdk.Config
+	if keyID == "" || secret == "" {
+		config = &sdk.Config{
+			Region:      sdk.String(DefaultRegion),
+			Credentials: credentials.NewEnvCredentials(), // Read Mattermost cloud credentials from the environment variables
+		}
+	} else {
+		config = &sdk.Config{
+			Region:      sdk.String(DefaultRegion),
+			Credentials: credentials.NewStaticCredentials(keyID, secret, ""),
+		}
+	}
+	client := NewAWSClientWithConfig(config)
+	c.cache[appID] = client
+
+	return client, nil
+}
+
+func (c *clientCache) get(appID string) (*Client, error) {
+	client, ok := c.cache[appID]
+	if !ok {
+		return nil, errors.New("no client")
+	}
+	return client, nil
+}

--- a/server/aws/credential_store.go
+++ b/server/aws/credential_store.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See License for license information.
+
+package aws
+
+import (
+	pluginapi "github.com/mattermost/mattermost-plugin-api"
+	"github.com/pkg/errors"
+)
+
+const prefixCred = "awscred"
+
+type store struct {
+	Mattermost *pluginapi.Client
+}
+
+type cred struct {
+	KeyID  string
+	Secret string
+}
+
+type CredentialStoreService interface {
+	GetAWSCredential(appID string) (keyID, secret string, err error)
+	StoreAWSCredential(appID, keyID, secret string) error
+	DeleteAWSCredential(appID string) error
+	GetAppList() ([]string, error)
+}
+
+func newCredentialStoreService(mm *pluginapi.Client) (CredentialStoreService, error) {
+	st := &store{
+		Mattermost: mm,
+	}
+	return st, st.initStore()
+}
+
+func (s *store) initStore() error {
+	appsKey := getAppsKey()
+	var value []string
+	err := s.Mattermost.KV.Get(appsKey, &value)
+	if err != nil {
+		return errors.Wrap(err, "can't get apps list from KV store")
+	}
+	if value == nil || len(value) == 0 {
+		ok, err := s.Mattermost.KV.Set(appsKey, &value)
+		if err != nil {
+			return errors.Wrapf(err, "can't set app list in KV store")
+		}
+		if !ok {
+			return errors.Errorf("can't set apps list in KV store")
+		}
+	}
+	return nil
+}
+
+func (s *store) GetAWSCredential(appID string) (keyID, secret string, err error) {
+	key := getKey(appID)
+	var value cred
+	if err := s.Mattermost.KV.Get(key, value); err != nil {
+		return "", "", errors.Wrapf(err, "can't get app %s credential from KV store", appID)
+	}
+	return value.KeyID, value.Secret, nil
+}
+
+func (s *store) StoreAWSCredential(appID, keyID, secret string) error {
+	key := getKey(appID)
+	value := &cred{
+		KeyID:  keyID,
+		Secret: secret,
+	}
+	ok, err := s.Mattermost.KV.Set(key, value)
+	if err != nil {
+		return errors.Wrapf(err, "can't set app %s credential from KV store", appID)
+	}
+	if !ok {
+		return errors.Errorf("can't set app %s credential from KV store", appID)
+	}
+
+	appsKey := getAppsKey()
+	var appsList []string
+	if err := s.Mattermost.KV.Get(appsKey, &appsList); err != nil {
+		return errors.Wrap(err, "can't get apps list from KV store")
+	}
+	appsList = append(appsList, appID)
+
+	ok, err = s.Mattermost.KV.Set(appsKey, &appsList)
+	if err != nil {
+		return errors.Wrap(err, "can't set apps list in KV store")
+	}
+	if !ok {
+		return errors.Errorf("can't set apps list in KV store")
+	}
+	return nil
+}
+
+func (s *store) DeleteAWSCredential(appID string) error {
+	key := getKey(appID)
+	if err := s.Mattermost.KV.Delete(key); err != nil {
+		return errors.Errorf("can't delete app %s credential from KV store", appID)
+	}
+
+	appsKey := getAppsKey()
+	var appsList []string
+	if err := s.Mattermost.KV.Get(appsKey, &appsList); err != nil {
+		return errors.Wrap(err, "can't get apps list from KV store")
+	}
+	var newList []string
+	for i, app := range appsList {
+		if app == appID {
+			newList = append(appsList[:i], appsList[i+1:]...)
+			break
+		}
+	}
+
+	ok, err := s.Mattermost.KV.Set(appsKey, &newList)
+	if err != nil {
+		return errors.Wrap(err, "can't set apps list in KV store")
+	}
+	if !ok {
+		return errors.Errorf("can't set apps list in KV store")
+	}
+	return nil
+}
+
+func (s *store) GetAppList() ([]string, error) {
+	key := getAppsKey()
+	var apps []string
+	if err := s.Mattermost.KV.Get(key, &apps); err != nil {
+		return nil, errors.Wrap(err, "can't retreive credential list from KV store")
+	}
+	return apps, nil
+}
+
+func getKey(appID string) string {
+	return prefixCred + "_" + appID
+}
+
+func getAppsKey() string {
+	return prefixCred + "_" + "apps"
+}

--- a/server/aws/credential_store.go
+++ b/server/aws/credential_store.go
@@ -40,7 +40,7 @@ func (s *store) initStore() error {
 	if err != nil {
 		return errors.Wrap(err, "can't get apps list from KV store")
 	}
-	if value == nil || len(value) == 0 {
+	if len(value) == 0 {
 		ok, err := s.Mattermost.KV.Set(appsKey, &value)
 		if err != nil {
 			return errors.Wrapf(err, "can't set app list in KV store")
@@ -77,7 +77,7 @@ func (s *store) StoreAWSCredential(appID, keyID, secret string) error {
 
 	appsKey := getAppsKey()
 	var appsList []string
-	if err := s.Mattermost.KV.Get(appsKey, &appsList); err != nil {
+	if err = s.Mattermost.KV.Get(appsKey, &appsList); err != nil {
 		return errors.Wrap(err, "can't get apps list from KV store")
 	}
 	appsList = append(appsList, appID)
@@ -103,15 +103,14 @@ func (s *store) DeleteAWSCredential(appID string) error {
 	if err := s.Mattermost.KV.Get(appsKey, &appsList); err != nil {
 		return errors.Wrap(err, "can't get apps list from KV store")
 	}
-	var newList []string
 	for i, app := range appsList {
 		if app == appID {
-			newList = append(appsList[:i], appsList[i+1:]...)
+			appsList = append(appsList[:i], appsList[i+1:]...)
 			break
 		}
 	}
 
-	ok, err := s.Mattermost.KV.Set(appsKey, &newList)
+	ok, err := s.Mattermost.KV.Set(appsKey, &appsList)
 	if err != nil {
 		return errors.Wrap(err, "can't set apps list in KV store")
 	}
@@ -125,7 +124,7 @@ func (s *store) GetAppList() ([]string, error) {
 	key := getAppsKey()
 	var apps []string
 	if err := s.Mattermost.KV.Get(key, &apps); err != nil {
-		return nil, errors.Wrap(err, "can't retreive credential list from KV store")
+		return nil, errors.Wrap(err, "can't retrieve credential list from KV store")
 	}
 	return apps, nil
 }

--- a/server/aws/install.go
+++ b/server/aws/install.go
@@ -139,15 +139,20 @@ func (c *Client) installApp(appName string, functions []functionInstallData) err
 
 	// check function name lengths
 	for _, function := range functions {
-		if len(function.name)+len(appName)+1 > lambdaFunctionFileNameMaxSize {
-			return errors.Errorf("function file name %s should be less than %d", appName+"_"+function.name, lambdaFunctionFileNameMaxSize)
+		name := createFunctionName(appName, function.name)
+		if len(name) > lambdaFunctionFileNameMaxSize {
+			return errors.Errorf("function file name %s should be less than %d", name, lambdaFunctionFileNameMaxSize)
 		}
 	}
 	for _, function := range functions {
-		name := fmt.Sprintf("%s_%s", appName, function.name)
+		name := createFunctionName(appName, function.name)
 		if err := c.CreateFunction(function.zipFile, name, function.handler, function.runtime, policyName); err != nil {
 			return errors.Wrapf(err, "can't install function for %s", appName)
 		}
 	}
 	return nil
+}
+
+func createFunctionName(appName, function string) string {
+	return fmt.Sprintf("%s_%s", appName, function)
 }

--- a/server/aws/proxy.go
+++ b/server/aws/proxy.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
+// See License for license information.
+
+package aws
+
+import (
+	pluginapi "github.com/mattermost/mattermost-plugin-api"
+	"github.com/pkg/errors"
+)
+
+// Proxy is an interface to communicate with AWS lambda functions
+type Proxy interface {
+	IsAppInstalled(appID string) bool
+	InstallApp(appID, releaseURL, keyID, secret string) error
+	InvokeFunction(appID, functionName string, request interface{}) ([]byte, error)
+}
+
+type proxy struct {
+	cc *clientCache
+}
+
+// NewAWSProxy creates proxy to communicate with AWS lambda functions
+func NewAWSProxy(mm *pluginapi.Client) Proxy {
+	store, err := newCredentialStoreService(mm)
+	if err != nil {
+		mm.Log.Error("can't create credential store", "err", err.Error())
+		return nil
+	}
+	cc, err := newClientCache(store)
+	if err != nil {
+		mm.Log.Error("can't create client cache", "err", err.Error())
+	}
+	return &proxy{
+		cc: cc,
+	}
+}
+
+func (p *proxy) IsAppInstalled(appID string) bool {
+	_, ok := p.cc.cache[appID]
+	return ok
+}
+
+func (p *proxy) InstallApp(appID, releaseURL, keyID, secret string) error {
+	if p.IsAppInstalled(appID) {
+		return errors.New("app is already installed")
+	}
+	if err := p.cc.store.StoreAWSCredential(appID, keyID, secret); err != nil {
+		return errors.Wrap(err, "can't store aws credentials in the KV store")
+	}
+	client, err := p.cc.create(appID)
+	if err != nil {
+		return errors.Wrapf(err, "can't create client for App %s and url %s", appID, releaseURL)
+	}
+	if err = client.InstallApp(releaseURL); err != nil {
+		return errors.Wrap(err, "can't install App")
+	}
+	return nil
+}
+
+func (p *proxy) InvokeFunction(appID, functionName string, request interface{}) ([]byte, error) {
+	if !p.IsAppInstalled(appID) {
+		return nil, errors.New("app is not installed")
+	}
+	client, _ := p.cc.cache[appID]
+	name := createFunctionName(appID, functionName)
+	return client.InvokeFunction(name, request)
+}

--- a/server/aws/proxy.go
+++ b/server/aws/proxy.go
@@ -36,8 +36,8 @@ func NewAWSProxy(mm *pluginapi.Client) Proxy {
 }
 
 func (p *proxy) IsAppInstalled(appID string) bool {
-	_, ok := p.cc.cache[appID]
-	return ok
+	_, err := p.cc.get(appID)
+	return err != nil
 }
 
 func (p *proxy) InstallApp(appID, releaseURL, keyID, secret string) error {
@@ -61,7 +61,7 @@ func (p *proxy) InvokeFunction(appID, functionName string, request interface{}) 
 	if !p.IsAppInstalled(appID) {
 		return nil, errors.New("app is not installed")
 	}
-	client, _ := p.cc.cache[appID]
+	client, _ := p.cc.get(appID)
 	name := createFunctionName(appID, functionName)
 	return client.InvokeFunction(name, request)
 }


### PR DESCRIPTION
#### Summary
This PR will add AWS client caching, also support of the Mattermost cloud. User can call 
`/apps experiment --app "appname" --release "http://github.com/....zip"` 
to install app in the Mattermost cloud. 

User should pass `keyID` and `secret` to install app in the 3rd party environment.
