### PR TITLE
Updates for dynamic modals

### DIFF
--- a/server/api/call.go
+++ b/server/api/call.go
@@ -18,6 +18,8 @@ const (
 	// CallTypeCancel is used for for the (rare?) case of when the form with
 	// SubmitOnCancel set is dismissed by the user.
 	CallTypeCancel = CallType("cancel")
+	// CallTypeLookup is used to fetch items for dynamic select elements
+	CallTypeLookup = CallType("lookup")
 )
 
 // A Call invocation is supplied a BotAccessToken as part of the context. If a
@@ -31,12 +33,12 @@ const (
 // TODO: what if a call needs a token and it was not provided? Return a call to
 // itself with Expand.
 type Call struct {
-	URL        string            `json:"url,omitempty"`
-	Type       CallType          `json:"type,omitempty"`
-	Values     map[string]string `json:"values,omitempty"`
-	Context    *Context          `json:"context,omitempty"`
-	RawCommand string            `json:"raw_command,omitempty"`
-	Expand     *Expand           `json:"expand,omitempty"`
+	URL        string                 `json:"url,omitempty"`
+	Type       CallType               `json:"type,omitempty"`
+	Values     map[string]interface{} `json:"values,omitempty"`
+	Context    *Context               `json:"context,omitempty"`
+	RawCommand string                 `json:"raw_command,omitempty"`
+	Expand     *Expand                `json:"expand,omitempty"`
 }
 
 type CallResponseType string
@@ -125,7 +127,7 @@ func MakeCall(url string, namevalues ...string) *Call {
 		URL: url,
 	}
 
-	values := map[string]string{}
+	values := map[string]interface{}{}
 	for len(namevalues) > 0 {
 		switch len(namevalues) {
 		case 1:
@@ -144,8 +146,21 @@ func MakeCall(url string, namevalues ...string) *Call {
 }
 
 func (c *Call) GetValue(name, defaultValue string) string {
-	if len(c.Values) == 0 || c.Values[name] == "" {
+	if len(c.Values) == 0 {
 		return defaultValue
 	}
-	return c.Values[name]
+
+	s, ok := c.Values[name].(string)
+	if ok && s != "" {
+		return s
+	}
+
+	opt, ok := c.Values[name].(map[string]interface{})
+	if ok {
+		if v, ok2 := opt["value"].(string); ok2 {
+			return v
+		}
+	}
+
+	return defaultValue
 }

--- a/server/api/call_test.go
+++ b/server/api/call_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,7 +16,11 @@ func TestUnmarshalCallRequest(t *testing.T) {
 			"mattermost_site_url": "https://levb.ngrok.io"
 		},
 		"values": {
-			"oauth2_client_secret": "cywc3e8nebyujrpuip98t69a3h"
+			"oauth2_client_secret": "cywc3e8nebyujrpuip98t69a3h",
+			"selected_option": {
+				"label": "The Label",
+				"value": "The Value"
+			}
 		}
 	}
 	`
@@ -27,4 +32,34 @@ func TestUnmarshalCallRequest(t *testing.T) {
 	require.Equal(t, "9pu8hstcpigm5x4dboe6hz9ddw", data.Context.TeamID)
 	require.Equal(t, "https://levb.ngrok.io", data.Context.MattermostSiteURL)
 	require.Equal(t, "cywc3e8nebyujrpuip98t69a3h", data.Values[PropOAuth2ClientSecret])
+	require.Equal(t, "The Value", data.GetValue("selected_option", ""))
+	require.Equal(t, "The Default Value", data.GetValue("nonexistent", "The Default Value"))
+}
+
+func TestMarshalCallResponse(t *testing.T) {
+	resStr := `{
+		"type": "form",
+		"form": {
+			"fields": [
+				{
+					"name": "field1",
+					"value": "value1"
+				}
+			]
+		}
+	}`
+	res := &CallResponse{}
+
+	err := json.Unmarshal([]byte(resStr), res)
+	require.NoError(t, err)
+
+	data, err := json.Marshal(res.Form.Fields[0])
+	require.NoError(t, err)
+
+	m := map[string]string{}
+	err = json.Unmarshal(data, &m)
+
+	require.NoError(t, err)
+	require.Equal(t, "field1", m["name"])
+	require.Equal(t, "value1", m["value"])
 }

--- a/server/api/field.go
+++ b/server/api/field.go
@@ -24,7 +24,7 @@ type Field struct {
 	IsRequired bool      `json:"is_required,omitempty"`
 
 	// Present (default) value of the field
-	Value string `json:"value,omitempty"`
+	Value interface{} `json:"value,omitempty"`
 
 	Description string `json:"description,omitempty"`
 
@@ -35,9 +35,8 @@ type Field struct {
 	ModalLabel string `json:"modal_label"`
 
 	// Select props
-	SelectRefreshOnChangeTo []string       `json:"refresh_on_change_to,omitempty"`
-	SelectSourceURL         string         `json:"source_url,omitempty"`
-	SelectStaticOptions     []SelectOption `json:"options,omitempty"`
+	SelectRefresh       bool           `json:"refresh,omitempty"`
+	SelectStaticOptions []SelectOption `json:"options,omitempty"`
 
 	// Text props
 	TextSubtype   string `json:"subtype,omitempty"`

--- a/server/api/form.go
+++ b/server/api/form.go
@@ -6,6 +6,8 @@ type Form struct {
 	Footer string `json:"footer,omitempty"`
 	Icon   string `json:"icon,omitempty"`
 
+	Call *Call `json:"call,omitempty"`
+
 	// SubmitButtons refers to a field name that must be a FieldTypeStaticSelect
 	// or FieldTypeDynamicSelect.
 	//

--- a/server/api/impl/admin/install.go
+++ b/server/api/impl/admin/install.go
@@ -49,7 +49,7 @@ func (adm *Admin) InstallApp(cc *api.Context, sessionToken api.SessionToken, in 
 	if install == nil {
 		install = api.DefaultInstallCall
 	}
-	install.Values = map[string]string{
+	install.Values = map[string]interface{}{
 		api.PropOAuth2ClientSecret: app.OAuth2ClientSecret,
 	}
 	install.Context = cc

--- a/server/examples/go/hello/bindings.go
+++ b/server/examples/go/hello/bindings.go
@@ -7,12 +7,12 @@ import (
 func Bindings() []*api.Binding {
 	justSend := api.MakeCall(PathSendSurvey)
 
-	modal := api.MakeCall(PathSendSurvey)
-	modal.Type = api.CallTypeForm
+	modal := api.MakeCall(PathSendSurveyModal)
 
-	modalFromPost := api.MakeCall(PathSendSurvey)
-	modalFromPost.Type = api.CallTypeForm
+	modalFromPost := api.MakeCall(PathSendSurveyModal)
 	modalFromPost.Expand = &api.Expand{Post: api.ExpandAll}
+
+	commandToModal := api.MakeCall(PathSendSurveyCommandToModal)
 	return []*api.Binding{
 		{
 			// TODO make this a subscribe button, with a state (current subscription status)
@@ -56,6 +56,12 @@ func Bindings() []*api.Binding {
 					Hint:        "[--user] message",
 					Description: "send a message to a user",
 					Call:        justSend,
+				}, {
+					Label:       "message-modal",
+					Location:    "message-modal",
+					Hint:        "[--message] message",
+					Description: "send a message to a user",
+					Call:        commandToModal,
 				}, {
 					Label:       "manage",
 					Location:    "manage",

--- a/server/examples/go/hello/builtin_hello/helloapp.go
+++ b/server/examples/go/hello/builtin_hello/helloapp.go
@@ -65,6 +65,10 @@ func (h *helloapp) Roundtrip(c *api.Call) (io.ReadCloser, error) {
 		cr = h.Install(c)
 	case hello.PathSendSurvey:
 		cr = h.SendSurvey(c)
+	case hello.PathSendSurveyModal:
+		cr = h.SendSurveyModal(c)
+	case hello.PathSendSurveyCommandToModal:
+		cr = h.SendSurveyCommandToModal(c)
 	case hello.PathSurvey:
 		cr = h.Survey(c)
 	default:
@@ -116,9 +120,28 @@ func (h *helloapp) SendSurvey(c *api.Call) *api.CallResponse {
 			Type:     api.CallResponseTypeOK,
 			Markdown: txt,
 		}
+	case api.CallTypeLookup:
+		return &api.CallResponse{
+			Data: map[string]interface{}{
+				"items": []*api.SelectOption{
+					{
+						Label: "Option 1",
+						Value: "option1",
+					},
+				},
+			},
+		}
 	}
 
 	return nil
+}
+
+func (h *helloapp) SendSurveyModal(c *api.Call) *api.CallResponse {
+	return hello.NewSendSurveyFormResponse(c)
+}
+
+func (h *helloapp) SendSurveyCommandToModal(c *api.Call) *api.CallResponse {
+	return hello.NewSendSurveyPartialFormResponse(c)
 }
 
 func (h *helloapp) Survey(c *api.Call) *api.CallResponse {

--- a/server/examples/go/hello/helloapp.go
+++ b/server/examples/go/hello/helloapp.go
@@ -11,10 +11,12 @@ const (
 )
 
 const (
-	PathSendSurvey        = "/send"
-	PathSubscribeChannel  = "/subscribe"
-	PathSurvey            = "/survey"
-	PathUserJoinedChannel = "/user-joined-channel"
+	PathSendSurvey               = "/send"
+	PathSendSurveyModal          = "/send-modal"
+	PathSendSurveyCommandToModal = "/send-command-modal"
+	PathSubscribeChannel         = "/subscribe"
+	PathSurvey                   = "/survey"
+	PathUserJoinedChannel        = "/user-joined-channel"
 )
 
 type HelloApp struct {

--- a/server/examples/go/hello/http_hello/functions.go
+++ b/server/examples/go/hello/http_hello/functions.go
@@ -47,6 +47,37 @@ func (h *helloapp) SendSurvey(w http.ResponseWriter, req *http.Request, claims *
 			Type:     api.CallResponseTypeOK,
 			Markdown: txt,
 		}
+	case api.CallTypeLookup:
+		out = &api.CallResponse{
+			Data: map[string]interface{}{
+				"items": []*api.SelectOption{
+					{
+						Label: "Option 1",
+						Value: "option1",
+					},
+				},
+			},
+		}
+	}
+
+	httputils.WriteJSON(w, out)
+	return http.StatusOK, nil
+}
+
+func (h *helloapp) SendSurveyModal(w http.ResponseWriter, req *http.Request, claims *api.JWTClaims, c *api.Call) (int, error) {
+	out := hello.NewSendSurveyFormResponse(c)
+	httputils.WriteJSON(w, out)
+	return http.StatusOK, nil
+}
+
+func (h *helloapp) SendSurveyCommandToModal(w http.ResponseWriter, req *http.Request, claims *api.JWTClaims, c *api.Call) (int, error) {
+	var out *api.CallResponse
+
+	switch c.Type {
+	case api.CallTypeSubmit:
+		out = hello.NewSendSurveyFormResponse(c)
+	default:
+		out = hello.NewSendSurveyPartialFormResponse(c)
 	}
 
 	httputils.WriteJSON(w, out)

--- a/server/examples/go/hello/http_hello/helloapp.go
+++ b/server/examples/go/hello/http_hello/helloapp.go
@@ -42,6 +42,8 @@ func Init(router *mux.Router, appsService *api.Service) {
 	handle(r, api.DefaultInstallCallPath, h.Install)
 	handle(r, api.DefaultBindingsCallPath, h.GetBindings)
 	handle(r, hello.PathSendSurvey, h.SendSurvey)
+	handle(r, hello.PathSendSurveyModal, h.SendSurveyModal)
+	handle(r, hello.PathSendSurveyCommandToModal, h.SendSurveyCommandToModal)
 	handle(r, hello.PathSurvey, h.Survey)
 	handle(r, hello.PathUserJoinedChannel, h.UserJoinedChannel)
 }

--- a/server/examples/go/hello/send_survey.go
+++ b/server/examples/go/hello/send_survey.go
@@ -74,6 +74,7 @@ func NewSendSurveyFormResponse(c *api.Call) *api.CallResponse {
 					AutocompleteHint:     "enter user ID or @user",
 					AutocompletePosition: 1,
 					Value:                submission.UserID,
+					SelectRefresh:        true,
 				}, {
 					Name:             "other",
 					Type:             api.FieldTypeDynamicSelect,
@@ -81,7 +82,6 @@ func NewSendSurveyFormResponse(c *api.Call) *api.CallResponse {
 					Label:            "other",
 					AutocompleteHint: "Pick one",
 					ModalLabel:       "Other",
-					SelectRefresh:    true,
 					Value:            submission.Other,
 				}, {
 					Name:             fieldMessage,

--- a/server/examples/go/hello/send_survey.go
+++ b/server/examples/go/hello/send_survey.go
@@ -1,6 +1,7 @@
 package hello
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/mattermost/mattermost-server/v5/model"
@@ -10,10 +11,50 @@ import (
 	"github.com/mattermost/mattermost-plugin-apps/server/utils/md"
 )
 
-func NewSendSurveyFormResponse(c *api.Call) *api.CallResponse {
+type SurveyFormSubmission struct {
+	UserID  string                 `json:"userID"`
+	Message string                 `json:"message"`
+	Other   map[string]interface{} `json:"other"`
+}
+
+func extractSurveyFormValues(c *api.Call) SurveyFormSubmission {
 	message := ""
+	userID := ""
+	var other map[string]interface{} = nil
 	if c.Context != nil && c.Context.Post != nil {
 		message = c.Context.Post.Message
+	}
+
+	topValues := c.Values
+	formValues := c.Values
+	if c.Type == api.CallTypeForm && topValues != nil {
+		formValues, _ = topValues["values"].(map[string]interface{})
+	}
+
+	if formValues != nil {
+		userID, _ = formValues["userID"].(string)
+		message, _ = formValues["message"].(string)
+		otherTemp, ok2 := formValues["other"].(map[string]interface{})
+		if ok2 {
+			other = otherTemp
+		} else {
+			other = nil
+		}
+	}
+
+	return SurveyFormSubmission{
+		UserID:  userID,
+		Message: message,
+		Other:   other,
+	}
+}
+
+func NewSendSurveyFormResponse(c *api.Call) *api.CallResponse {
+	submission := extractSurveyFormValues(c)
+	name, _ := c.Values["name"].(string)
+
+	if name == "userID" {
+		submission.Message = fmt.Sprintf("%s Now sending to %s.", submission.Message, submission.UserID)
 	}
 
 	return &api.CallResponse{
@@ -22,6 +63,7 @@ func NewSendSurveyFormResponse(c *api.Call) *api.CallResponse {
 			Title:  "Send a survey to user",
 			Header: "Message modal form header",
 			Footer: "Message modal form footer",
+			Call:   api.MakeCall(PathSendSurvey),
 			Fields: []*api.Field{
 				{
 					Name:                 fieldUserID,
@@ -31,6 +73,16 @@ func NewSendSurveyFormResponse(c *api.Call) *api.CallResponse {
 					ModalLabel:           "User",
 					AutocompleteHint:     "enter user ID or @user",
 					AutocompletePosition: 1,
+					Value:                submission.UserID,
+				}, {
+					Name:             "other",
+					Type:             api.FieldTypeDynamicSelect,
+					Description:      "Some values",
+					Label:            "other",
+					AutocompleteHint: "Pick one",
+					ModalLabel:       "Other",
+					SelectRefresh:    true,
+					Value:            submission.Other,
 				}, {
 					Name:             fieldMessage,
 					Type:             api.FieldTypeText,
@@ -42,7 +94,38 @@ func NewSendSurveyFormResponse(c *api.Call) *api.CallResponse {
 					TextSubtype:      "textarea",
 					TextMinLength:    2,
 					TextMaxLength:    1024,
-					Value:            message,
+					Value:            submission.Message,
+				},
+			},
+		},
+	}
+}
+
+func NewSendSurveyPartialFormResponse(c *api.Call) *api.CallResponse {
+	if c.Type == api.CallTypeSubmit {
+		return NewSendSurveyFormResponse(c)
+	}
+
+	return &api.CallResponse{
+		Type: api.CallResponseTypeForm,
+		Form: &api.Form{
+			Title:  "Send a survey to user",
+			Header: "Message modal form header",
+			Footer: "Message modal form footer",
+			Call:   api.MakeCall(PathSendSurveyCommandToModal),
+			Fields: []*api.Field{
+				{
+					Name:             fieldMessage,
+					Type:             api.FieldTypeText,
+					Description:      "Text to ask the user about",
+					IsRequired:       true,
+					Label:            "message",
+					ModalLabel:       "Text",
+					AutocompleteHint: "Anything you want to say",
+					TextSubtype:      "textarea",
+					TextMinLength:    2,
+					TextMaxLength:    1024,
+					Value:            "",
 				},
 			},
 		},

--- a/server/http/restapi/call.go
+++ b/server/http/restapi/call.go
@@ -23,6 +23,10 @@ func (a *restapi) handleCall(w http.ResponseWriter, req *http.Request) {
 		httputils.WriteUnauthorizedError(w, err)
 		return
 	}
+
+	if call.Context == nil {
+		call.Context = &api.Context{}
+	}
 	call.Context.ActingUserID = actingUserID
 
 	sessionID := req.Header.Get("MM_SESSION_ID")


### PR DESCRIPTION
#### Summary

Each call related to a form uses the same URL:
- fetching form `{type: 'form'}`
- dynamic lookup `{type: 'lookup'}`
- selected significant value `{type: 'form'}`
- submitted form `{type: ''}`

A modal will be opened on the frontend on any call if:
- `call.type` == `submit` (actually empty string at the moment)
- and `callResponse.type` == `form`

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-30814
Fixes https://mattermost.atlassian.net/browse/MM-30813

#### Related Pull Requests

https://github.com/mattermost/mattermost-webapp/pull/7166
https://github.com/mattermost/mattermost-redux/pull/1322