### PR TITLE
Fix markdown formatting for /apps list with more then one app installed

### DIFF
--- a/server/api/impl/admin/list.go
+++ b/server/api/impl/admin/list.go
@@ -19,8 +19,8 @@ func (adm *Admin) ListApps() ([]*api.App, md.MD, error) {
 | :-- |:-----| :----- | :-- | :-------- | :---------- |
 `)
 	for _, app := range apps {
-		out += md.Markdownf(`|%s|%s|%s|%s|%s|%s|`,
-			app.Manifest.AppID, app.Manifest.Type, app.OAuth2ClientID, app.BotUserID, app.GrantedLocations, app.GrantedPermissions)
+		out += md.Markdownf(`|%s|%s|%s|%s|%s|%s|
+		`, app.Manifest.AppID, app.Manifest.Type, app.OAuth2ClientID, app.BotUserID, app.GrantedLocations, app.GrantedPermissions)
 	}
 
 	return apps, out, nil


### PR DESCRIPTION
#### Summary
Fix markdown formatting for `/apps list` with more then one app installed

#### Ticket Link
None
