### PR TITLE
[MM-32476] Apps in the Marketplace

### DIFF
--- a/server/api/constants.go
+++ b/server/api/constants.go
@@ -29,6 +29,9 @@ const (
 	PathOAuth2         = "/oauth2"          // convention for Mattermost Apps, comes from OAuther
 	PathOAuth2Complete = "/oauth2/complete" // convention for Mattermost Apps, comes from OAuther
 
+	// Marketplace sub-paths.
+	PathMarketplace = "/marketplace"
+
 	// Other sub-paths.
 	CallPath        = "/call"
 	KVPath          = "/kv"

--- a/server/http/restapi/marketplace.go
+++ b/server/http/restapi/marketplace.go
@@ -1,0 +1,145 @@
+package restapi
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/mattermost/mattermost-plugin-apps/apps"
+	"github.com/mattermost/mattermost-plugin-apps/server/utils/httputils"
+
+	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/pkg/errors"
+)
+
+type MarketplaceApp struct {
+	Installed bool                     `json:"installed"`
+	Labels    []model.MarketplaceLabel `json:"labels,omitempty"`
+	Manifest  apps.Manifest            `json:"manifest"`
+}
+
+func (a *restapi) handleGetMarketplace(w http.ResponseWriter, req *http.Request, actingUserID string) {
+	filter := req.URL.Query().Get("filter")
+
+	localApps, err := a.getLocalApps()
+	if err != nil {
+		httputils.WriteInternalServerError(w, err)
+		return
+	}
+
+	remoteApps, err := a.getRemoteApps()
+	if err != nil {
+		httputils.WriteInternalServerError(w, err)
+		return
+	}
+
+	apps := mergeApps(remoteApps, localApps)
+
+	// Filter plugins.
+	var result []MarketplaceApp
+	for _, a := range apps {
+		if appMatchesFilter(a.Manifest, filter) {
+			result = append(result, a)
+		}
+	}
+
+	// Sort result alphabetically.
+	sort.SliceStable(result, func(i, j int) bool {
+		return strings.ToLower(result[i].Manifest.DisplayName) <
+			strings.ToLower(result[j].Manifest.DisplayName)
+	})
+
+	httputils.WriteJSON(w, result)
+}
+
+func (a *restapi) getLocalApps() ([]MarketplaceApp, error) {
+	apps, _, err := a.api.Admin.ListApps()
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to list local apps")
+	}
+
+	result := make([]MarketplaceApp, len(apps))
+	for i := 0; i < len(apps); i++ {
+		result[i] = MarketplaceApp{
+			Manifest:  *apps[i].Manifest,
+			Installed: true,
+		}
+	}
+
+	return result, nil
+}
+
+func (a *restapi) getRemoteApps() ([]MarketplaceApp, error) {
+	m := apps.Manifest{
+		AppID:       "zendesk",
+		Type:        apps.AppTypeHTTP,
+		DisplayName: "Zendesk",
+		Description: "A Zendesk App.",
+		HomepageURL: "https://github.com/mattermost/mattermost-app-zendesk",
+		HTTPRootURL: "http://localhost:4000/mattermost/manifest.json",
+		RequestedPermissions: apps.Permissions{
+			apps.PermissionActAsUser,
+			apps.PermissionActAsBot,
+		},
+		RequestedLocations: apps.Locations{
+			apps.LocationCommand,
+			apps.LocationChannelHeader,
+			apps.LocationInPost,
+			apps.LocationPostMenu,
+		},
+	}
+
+	result := []MarketplaceApp{{
+		Manifest:  m,
+		Installed: false,
+	}}
+
+	return result, nil
+}
+
+// mergeApps merges two slices of marketplace apps.
+// If two items have the same id, the one from the first slice is keeped.
+func mergeApps(a []MarketplaceApp, b []MarketplaceApp) []MarketplaceApp {
+	appMap := map[string]*MarketplaceApp{}
+	for i := range a {
+		id := string(a[i].Manifest.AppID)
+		appMap[id] = &a[i]
+	}
+
+	for i := range b {
+		id := string(b[i].Manifest.AppID)
+		if appMap[id] == nil {
+			appMap[id] = &b[i]
+		}
+	}
+
+	result := []MarketplaceApp{}
+	for _, a := range appMap {
+		result = append(result, *a)
+	}
+
+	return result
+}
+
+// Copied from Mattermost Server
+func appMatchesFilter(manifest apps.Manifest, filter string) bool {
+	filter = strings.TrimSpace(strings.ToLower(filter))
+
+	if filter == "" {
+		return true
+	}
+
+	if strings.ToLower(string(manifest.AppID)) == filter {
+		return true
+	}
+
+	if strings.Contains(strings.ToLower(manifest.DisplayName), filter) {
+		return true
+	}
+
+	if strings.Contains(strings.ToLower(manifest.Description), filter) {
+		return true
+	}
+
+	return false
+}

--- a/server/http/restapi/marketplace_test.go
+++ b/server/http/restapi/marketplace_test.go
@@ -1,0 +1,90 @@
+package restapi
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost-plugin-apps/apps"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeApps(t *testing.T) {
+	for name, test := range map[string]struct {
+		a        []MarketplaceApp
+		b        []MarketplaceApp
+		expected []MarketplaceApp
+	}{
+		"same slices": {
+			a: []MarketplaceApp{{
+				Manifest: apps.Manifest{
+					AppID: "someID",
+				}},
+			},
+			b: []MarketplaceApp{{
+				Manifest: apps.Manifest{
+					AppID: "someID",
+				}},
+			},
+			expected: []MarketplaceApp{{
+				Manifest: apps.Manifest{
+					AppID: "someID",
+				}},
+			},
+		},
+		"a is empty": {
+			a: []MarketplaceApp{},
+			b: []MarketplaceApp{{
+				Manifest: apps.Manifest{
+					AppID: "someID",
+				}},
+			},
+			expected: []MarketplaceApp{{
+				Manifest: apps.Manifest{
+					AppID: "someID",
+				}},
+			},
+		},
+		"b is empty": {
+			a: []MarketplaceApp{{
+				Manifest: apps.Manifest{
+					AppID: "someID",
+				}},
+			},
+			b: []MarketplaceApp{},
+			expected: []MarketplaceApp{{
+				Manifest: apps.Manifest{
+					AppID: "someID",
+				}},
+			},
+		},
+		"two different elements": {
+			a: []MarketplaceApp{{
+				Manifest: apps.Manifest{
+					AppID: "someID",
+				}},
+			},
+			b: []MarketplaceApp{{
+				Manifest: apps.Manifest{
+					AppID: "some other ID",
+				}},
+			},
+			expected: []MarketplaceApp{
+				{
+					Manifest: apps.Manifest{
+						AppID: "someID",
+					},
+				},
+				{
+					Manifest: apps.Manifest{
+						AppID: "some other ID",
+					},
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result := mergeApps(test.a, test.b)
+
+			assert.ElementsMatch(t, test.expected, result)
+		})
+	}
+}

--- a/server/http/restapi/marketplace_test.go
+++ b/server/http/restapi/marketplace_test.go
@@ -56,6 +56,11 @@ func TestMergeApps(t *testing.T) {
 				}},
 			},
 		},
+		"both empty": {
+			a:        []MarketplaceApp{},
+			b:        []MarketplaceApp{},
+			expected: []MarketplaceApp{},
+		},
 		"two different elements": {
 			a: []MarketplaceApp{{
 				Manifest: apps.Manifest{
@@ -76,6 +81,28 @@ func TestMergeApps(t *testing.T) {
 				{
 					Manifest: apps.Manifest{
 						AppID: "some other ID",
+					},
+				},
+			},
+		},
+		"same element, should take first": {
+			a: []MarketplaceApp{{
+				Manifest: apps.Manifest{
+					AppID:       "someID",
+					Description: "someDescription",
+				}},
+			},
+			b: []MarketplaceApp{{
+				Manifest: apps.Manifest{
+					AppID:       "someID",
+					Description: "someOtherDescription",
+				}},
+			},
+			expected: []MarketplaceApp{
+				{
+					Manifest: apps.Manifest{
+						AppID:       "someID",
+						Description: "someDescription",
 					},
 				},
 			},

--- a/server/http/restapi/restapi.go
+++ b/server/http/restapi/restapi.go
@@ -30,9 +30,11 @@ func Init(router *mux.Router, appsService *api.Service) {
 	subrouter.HandleFunc(api.KVPath+"/", a.handleKV(a.kvList)).Methods("GET")
 	subrouter.HandleFunc(api.KVPath+"/{key}", a.handleKV(a.kvHead)).Methods("HEAD")
 	subrouter.HandleFunc(api.KVPath+"/{key}", a.handleKV(a.kvDelete)).Methods("DELETE")
+
+	subrouter.HandleFunc(api.PathMarketplace, checkAuthorized(a.handleGetMarketplace)).Methods(http.MethodGet)
 }
 
-func checkAuthorized(f func(http.ResponseWriter, *http.Request, string)) func(http.ResponseWriter, *http.Request) {
+func checkAuthorized(f func(http.ResponseWriter, *http.Request, string)) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		actingUserID := req.Header.Get("Mattermost-User-Id")
 		if actingUserID == "" {


### PR DESCRIPTION
#### Summary
This PR adds an `/marketplace` endpoint to the plugin. It's used by the webapp to fetch the list of installed and available apps. The latter is a hard coded list for now as discussed in the Apps meeting.

I've added Zendesk as a POW. It only works if the App runs locally, given that it's not yet in AWS.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32476
https://mattermost.atlassian.net/browse/MM-32535
https://mattermost.atlassian.net/browse/MM-32539