### PR TITLE
Fix panic that happens on server restart

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -64,6 +64,7 @@ func (p *Plugin) OnActivate() error {
 	awsClient := aws.NewAWSClient(stored.AWSAccessKeyID, stored.AWSSecretAccessKey, &mm.Log)
 
 	conf := configurator.NewConfigurator(mm, awsClient, p.BuildConfig, botUserID)
+	conf.RefreshConfig(&stored)
 	store := store.NewStore(mm, conf)
 	proxy := proxy.NewProxy(mm, awsClient, conf, store)
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -64,7 +64,7 @@ func (p *Plugin) OnActivate() error {
 	awsClient := aws.NewAWSClient(stored.AWSAccessKeyID, stored.AWSSecretAccessKey, &mm.Log)
 
 	conf := configurator.NewConfigurator(mm, awsClient, p.BuildConfig, botUserID)
-	conf.RefreshConfig(&stored)
+	_ = conf.RefreshConfig(&stored)
 	store := store.NewStore(mm, conf)
 	proxy := proxy.NewProxy(mm, awsClient, conf, store)
 


### PR DESCRIPTION
#### Summary
The error came from the embedded struct (StoredConfig) not being init on server restart.

This was due to the server not calling "OnConfigurationChange" after activate. On Enable it behaves like that, (first activate, then onconfigurationchange), but not on server restart.

#### Ticket Link
None