### PR TITLE
Reduced the linked image size

### DIFF
--- a/server/api/mock_api/mock_appservices.go
+++ b/server/api/mock_api/mock_appservices.go
@@ -5,11 +5,9 @@
 package mock_api
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
-
 	apps "github.com/mattermost/mattermost-plugin-apps/apps"
+	reflect "reflect"
 )
 
 // MockAppServices is a mock of AppServices interface

--- a/server/api/mock_api/mock_proxy.go
+++ b/server/api/mock_api/mock_proxy.go
@@ -5,12 +5,10 @@
 package mock_api
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
-
 	apps "github.com/mattermost/mattermost-plugin-apps/apps"
 	api "github.com/mattermost/mattermost-plugin-apps/server/api"
+	reflect "reflect"
 )
 
 // MockProxy is a mock of Proxy interface

--- a/server/http/restapi/restapitestlib.go
+++ b/server/http/restapi/restapitestlib.go
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+// +build e2e
 
 package restapi
 


### PR DESCRIPTION
Reduced the executable size by removing `server/http/restapi/restapitestlib.go` from the default build, tagged it as `e2e`.

![image](https://user-images.githubusercontent.com/1187448/107886157-08286b00-6eb3-11eb-8850-255fb119b730.png)
vs
![image](https://user-images.githubusercontent.com/1187448/107886201-3443ec00-6eb3-11eb-923e-1ec4a449e341.png)
