### PR TITLE
[MM-32862] Sanitized app version and id for function name

### DIFF
--- a/apps/app.go
+++ b/apps/app.go
@@ -1,17 +1,69 @@
 package apps
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"unicode"
 
+	"github.com/pkg/errors"
+)
+
+// AppID is a globally unique identifier that represents a Mattermost App.
+// Allowed characters are letters, numbers, underscores and hyphens.
 type AppID string
-type AppType string
+
+func (id AppID) IsValid() error {
+	for _, c := range id {
+		if unicode.IsLetter(c) {
+			continue
+		}
+
+		if unicode.IsNumber(c) {
+			continue
+		}
+
+		if c == '-' || c == '_' {
+			continue
+		}
+
+		return errors.Errorf("invalid character %v in appID", c)
+	}
+
+	return nil
+}
+
+// AppVersion is the version of a Mattermost App.
+// Allowed characters are letters, numbers, underscores and hyphens.
 type AppVersion string
+
+func (v AppVersion) IsValid() error {
+	for _, c := range v {
+		if unicode.IsLetter(c) {
+			continue
+		}
+
+		if unicode.IsNumber(c) {
+			continue
+		}
+
+		if c == '-' || c == '_' {
+			continue
+		}
+
+		return errors.Errorf("invalid character %v in appVersion", c)
+	}
+
+	return nil
+}
+
 type AppVersionMap map[AppID]AppVersion
+
+type AppType string
 
 // default is HTTP
 const (
-	AppTypeHTTP      = "http"
-	AppTypeAWSLambda = "aws_lambda"
-	AppTypeBuiltin   = "builtin"
+	AppTypeHTTP      AppType = "http"
+	AppTypeAWSLambda AppType = "aws_lambda"
+	AppTypeBuiltin   AppType = "builtin"
 )
 
 func (at AppType) IsValid() bool {


### PR DESCRIPTION
#### Summary
AWS only allows letters, number, underscores and hyphens as function names.


Given that the app id and version are used to generate the function name, we need to limit the characters used in them to only the ones stated above. A version is likely contains a dots, hence I think it's fine to sanitized it before generating the function name.

I've also added an `IsValid` method to `AppID` and `AppVersion` to state that. They should get called in the provision process, but the seemed out of scope for this PR.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32862
