### PR TITLE
[MM-32702] Introduce appsctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ Change your directory back to `mattermost-plugin-apps` and run the end to end te
 make test-e2e
 ```
 
+## Provisioning
+
+To provision an App to AWS you first need to store your AWS access key in an environment variable called `APPS_PROVISION_AWS_ACCESS_KEY` and the secret key in `APPS_PROVISION_AWS_SECRET_KEY`.
+
+Only once you need to run `go run ./cmd/appsctl/ provision bucket` to create the s3 bucket.
+
+To provision an app run `go run ./cmd/appsctl/ provision app /PATH/TO/YOUR/APP/BUNDLE`. Use `--update` to update the lambda functions if they already exist. This option should not be used in production.
+
 ## Contacts
 
 Dev: Lev Brouk (@lev.brouk)

--- a/assets/apps.json
+++ b/assets/apps.json
@@ -1,7 +1,6 @@
 {
     "apps" : {
-        "zendesk" : "0.0.1"
-    },
-    "overrides" : {
+        "zendesk" : "0.0.1",
+        "com.mattermost.servicenow" : "0.1.0"
     }
 }

--- a/assets/apps.json
+++ b/assets/apps.json
@@ -1,11 +1,7 @@
 {
     "apps" : {
-        "jira" : "v3.0.0",
-        "todo" : "v2.2.3"
+        "zendesk" : "0.0.1"
     },
     "overrides" : {
-        "my_installation_id" : {
-            "jira" : "v.3.0.1"
-        }
     }
 }

--- a/cmd/appsctl/completion.go
+++ b/cmd/appsctl/completion.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+}
+
+var completionCmd = &cobra.Command{
+	Use:   "completion [bash|zsh|fish|powershell]",
+	Short: "Generate completion script",
+	Long: `To load completions:
+
+Bash:
+
+$ source <(pluginops completion bash)
+
+# To load completions for each session, execute once:
+Linux:
+  $ pluginops completion bash > /etc/bash_completion.d/pluginops
+MacOS:
+  $ pluginops completion bash > /usr/local/etc/bash_completion.d/pluginops
+
+Zsh:
+
+# If shell completion is not already enabled in your environment you will need
+# to enable it.  You can execute the following once:
+
+$ echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+# To load completions for each session, execute once:
+$ pluginops completion zsh > "${fpath[1]}/_pluginops"
+
+# You will need to start a new shell for this setup to take effect.
+
+Fish:
+
+$ pluginops completion fish | source
+
+# To load completions for each session, execute once:
+$ pluginops completion fish > ~/.config/fish/completions/pluginops.fish
+`,
+	DisableFlagsInUseLine: true,
+	ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+	Args:                  cobra.ExactValidArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		switch args[0] {
+		case "bash":
+			return cmd.Root().GenBashCompletion(os.Stdout)
+		case "zsh":
+			return cmd.Root().GenZshCompletion(os.Stdout)
+		case "fish":
+			return cmd.Root().GenFishCompletion(os.Stdout, true)
+		case "powershell":
+			return cmd.Root().GenPowerShellCompletion(os.Stdout)
+		default:
+			return errors.Errorf("unknown sheell type %v", args[0])
+		}
+	},
+}

--- a/cmd/appsctl/log.go
+++ b/cmd/appsctl/log.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+var log logger
+
+type logger struct {
+	*logrus.Logger
+}
+
+func init() {
+	log = logger{
+		Logger: logrus.New(),
+	}
+}
+
+func (l *logger) Error(message string, keyValuePairs ...interface{}) {
+	l.WithFields(getFields(keyValuePairs...)).Error(message)
+}
+
+func (l *logger) Warn(message string, keyValuePairs ...interface{}) {
+	l.WithFields(getFields(keyValuePairs...)).Warn(message)
+}
+func (l *logger) Info(message string, keyValuePairs ...interface{}) {
+	l.WithFields(getFields(keyValuePairs...)).Info(message)
+}
+func (l *logger) Debug(message string, keyValuePairs ...interface{}) {
+	l.WithFields(getFields(keyValuePairs...)).Debug(message)
+}
+
+func getFields(keyValuePairs ...interface{}) logrus.Fields {
+	fields := logrus.Fields{}
+
+	if len(keyValuePairs)%2 != 0 {
+		panic("invalid logging key value data")
+	}
+
+	for i := 0; i < len(keyValuePairs); i += 2 {
+		fields[keyValuePairs[i].(string)] = keyValuePairs[i+1]
+	}
+
+	return fields
+}

--- a/cmd/appsctl/main.go
+++ b/cmd/appsctl/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/mattermost/mattermost-plugin-apps/server/api/impl/aws"
+)
+
+var (
+	verbose bool
+)
+
+func init() {
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")
+}
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		log.WithError(err).Fatal("command failed")
+	}
+}
+
+var rootCmd = &cobra.Command{
+	Use:   "appsctl",
+	Short: "A tool to manage Mattermost apps.",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if verbose {
+			log.SetLevel(logrus.DebugLevel)
+		}
+	},
+}
+
+func createAWSClient() (*aws.Client, error) {
+	accessKey := os.Getenv("APPS_PROVISION_AWS_ACCESS_KEY")
+	secretKey := os.Getenv("APPS_PROVISION_AWS_SECRET_KEY")
+
+	if accessKey == "" {
+		return nil, errors.New("no AWS access key was provided. Please set APPS_PROVISION_AWS_ACCESS_KEY")
+	}
+
+	if secretKey == "" {
+		return nil, errors.New("no AWS secret key was provided. Please set APPS_PROVISION_AWS_SECRET_KEY")
+	}
+
+	return aws.NewAWSClient(accessKey, secretKey, &log), nil
+}

--- a/cmd/appsctl/provision.go
+++ b/cmd/appsctl/provision.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	shouldUpdate bool
+)
+
+func init() {
+	rootCmd.AddCommand(
+		provisionCmd,
+	)
+
+	provisionCmd.AddCommand(
+		provisionAppCmd,
+		provisionBucketCmd,
+	)
+
+	provisionAppCmd.Flags().BoolVar(&shouldUpdate, "update", false, "Update functions if they already exist. Use with causion in production.")
+}
+
+var provisionCmd = &cobra.Command{
+	Use:   "provision",
+	Short: "Provision aws resources",
+}
+
+var provisionAppCmd = &cobra.Command{
+	Use:   "app",
+	Short: "Provision a Mattermost app",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		awsClient, err := createAWSClient()
+		if err != nil {
+			return err
+		}
+
+		err = awsClient.ProvisionAppFromFile(args[0], shouldUpdate)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+var provisionBucketCmd = &cobra.Command{
+	Use:   "bucket",
+	Short: "Provision the central s3 bucket used to store app data",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		awsClient, err := createAWSClient()
+		if err != nil {
+			return err
+		}
+
+		name := awsClient.AppsS3Bucket
+
+		exists, err := awsClient.CheckIfBucketExists(name)
+		if err != nil {
+			return err
+		}
+
+		if exists {
+			log.Infof("Bucket %v already exists", name)
+			return nil
+		}
+
+		err = awsClient.CreateBucket(name)
+		if err != nil {
+			return err
+		}
+
+		log.Infof("Created bucket %s", name)
+
+		return nil
+	},
+}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,8 @@ require (
 	github.com/mattermost/mattermost-plugin-api v0.0.12
 	github.com/mattermost/mattermost-server/v5 v5.3.2-0.20200929105438-ed2cd0e55219
 	github.com/pkg/errors v0.9.1
-	github.com/sirupsen/logrus v1.7.0 // indirect
+	github.com/sirupsen/logrus v1.7.1
+	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 )

--- a/go.sum
+++ b/go.sum
@@ -367,6 +367,7 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/icrowley/fake v0.0.0-20180203215853-4178557ae428/go.mod h1:uhpZMVGznybq1itEKXj6RYw9I71qK4kH+OGMjRC4KEo=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/iris-contrib/blackfriday v2.0.0+incompatible/go.mod h1:UzZ2bDEoaSGPbkg6SAB4att1aAwTmVIx/5gCVqeyUdI=
@@ -451,6 +452,8 @@ github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-b
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
+github.com/magefile/mage v1.10.0 h1:3HiXzCUY12kh9bIuyXShaVe529fJfyqoVM42o/uom2g=
+github.com/magefile/mage v1.10.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -731,8 +734,8 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
-github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
-github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/sirupsen/logrus v1.7.1 h1:rsizeFmZP+GYwyb4V6t6qpG7ZNWzA2bvgW/yC2xHCcg=
+github.com/sirupsen/logrus v1.7.1/go.mod h1:4GuYW9TZmE769R5STWrRakJc4UqQ3+QQ95fyz7ENv1A=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.0.0 h1:UVQPSSmc3qtTi+zPPkCXvZX9VvW/xT/NsRvKfwY81a8=
 github.com/smartystreets/assertions v1.0.0/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
@@ -754,6 +757,7 @@ github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
+github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=

--- a/server/api/aws.go
+++ b/server/api/aws.go
@@ -6,6 +6,5 @@ package api
 import "github.com/mattermost/mattermost-plugin-apps/apps"
 
 type AWS interface {
-	ProvisionAppFromURL(releaseURL string, shouldUpdate bool) error
 	InvokeLambda(appID apps.AppID, appVersion apps.AppVersion, functionName, invocationType string, request interface{}) ([]byte, error)
 }

--- a/server/api/aws.go
+++ b/server/api/aws.go
@@ -6,6 +6,6 @@ package api
 import "github.com/mattermost/mattermost-plugin-apps/apps"
 
 type AWS interface {
-	ProvisionApp(releaseURL string) error
+	ProvisionAppFromURL(releaseURL string, shouldUpdate bool) error
 	InvokeLambda(appID apps.AppID, appVersion apps.AppVersion, functionName, invocationType string, request interface{}) ([]byte, error)
 }

--- a/server/api/impl/aws/provision_app.go
+++ b/server/api/impl/aws/provision_app.go
@@ -256,9 +256,13 @@ func (c *Client) createFunction(zipFile io.Reader, function, handler, runtime, r
 		if _, ok := err.(*lambda.ResourceConflictException); !ok {
 			return errors.Wrapf(err, "Can't create function. Response: %v\n", result)
 		}
+
+		c.logger.Info(fmt.Sprintf("funcion %s already exists. Not updating it.", function))
+
+		return nil
 	}
 
-	c.logger.Info(fmt.Sprintf("function named %s was created with response: %v", function, result))
+	c.logger.Info(fmt.Sprintf("function %s was created with response: %v", function, result))
 
 	return nil
 }

--- a/server/api/impl/aws/provision_app.go
+++ b/server/api/impl/aws/provision_app.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/aws/aws-sdk-go/service/lambda"
@@ -45,21 +46,42 @@ type functionInstallData struct {
 //      |-- lambda_function.py
 //      |-- __pycache__
 //      |-- certifi/
-func (c *Client) ProvisionApp(releaseURL string) error {
+func (c *Client) ProvisionAppFromURL(releaseURL string, shouldUpdate bool) error {
 	zipFile, err := downloadFile(releaseURL)
 	if err != nil {
 		return errors.Wrapf(err, "can't install app from url %s", releaseURL)
 	}
-	zipReader, err := zip.NewReader(bytes.NewReader(zipFile), int64(len(zipFile)))
+
+	return c.ProvisionApp(zipFile, shouldUpdate)
+}
+
+func (c *Client) ProvisionAppFromFile(path string, shouldUpdate bool) error {
+	f, err := os.Open(path)
 	if err != nil {
-		return errors.Wrapf(err, "can't install app from url %s", releaseURL)
+		return errors.Wrapf(err, "can't read file from  path %s", path)
+	}
+
+	b, err := ioutil.ReadAll(f)
+	if err != nil {
+		return errors.Wrap(err, "can't read file")
+	}
+
+	return c.ProvisionApp(b, shouldUpdate)
+}
+
+func (c *Client) ProvisionApp(b []byte, shouldUpdate bool) error {
+	zipReader, err := zip.NewReader(bytes.NewReader(b), int64(len(b)))
+	if err != nil {
+		return errors.Wrap(err, "can't get zip reader")
 	}
 	bundleFunctions := []functionInstallData{}
-	var mani apps.Manifest
+	var mani *apps.Manifest
 
 	// Read all the files from zip archive
 	for _, file := range zipReader.File {
-		if strings.HasSuffix(file.Name, "manifest.json") {
+		switch {
+		case strings.HasSuffix(file.Name, "manifest.json"):
+
 			manifestFile, err := file.Open()
 			if err != nil {
 				return errors.Wrap(err, "can't open manifest.json file")
@@ -74,7 +96,7 @@ func (c *Client) ProvisionApp(releaseURL string) error {
 			if err != nil {
 				return errors.Wrapf(err, "can't unmarshal manifest.json file %s", string(data))
 			}
-		} else if strings.HasSuffix(file.Name, ".zip") {
+		case strings.HasSuffix(file.Name, ".zip"):
 			lambdaFunctionFile, err := file.Open()
 			if err != nil {
 				return errors.Wrapf(err, "can't open file %s", file.Name)
@@ -85,8 +107,16 @@ func (c *Client) ProvisionApp(releaseURL string) error {
 				name:    strings.TrimSuffix(file.Name, ".zip"),
 				zipFile: lambdaFunctionFile,
 			})
+			c.logger.Debug("Found function bundle", "file", file.Name)
+		default:
+			c.logger.Info("Unknown file found in app bundle", "file", file.Name)
 		}
 	}
+
+	if mani == nil {
+		return errors.New("no manifest found")
+	}
+
 	resFunctions := []functionInstallData{}
 
 	// O(n^2) code for simplicity
@@ -103,7 +133,7 @@ func (c *Client) ProvisionApp(releaseURL string) error {
 			}
 		}
 	}
-	return c.provisionApp(mani.AppID, mani.Version, resFunctions)
+	return c.provisionApp(mani.AppID, mani.Version, resFunctions, shouldUpdate)
 }
 
 func downloadFile(url string) ([]byte, error) {
@@ -135,7 +165,7 @@ func isValid(url string) bool {
 	return strings.HasPrefix(url, "https://github.com/")
 }
 
-func (c *Client) provisionApp(appID apps.AppID, appVersion apps.AppVersion, functions []functionInstallData) error {
+func (c *Client) provisionApp(appID apps.AppID, appVersion apps.AppVersion, functions []functionInstallData, shouldUpdate bool) error {
 	policyName, err := c.makeLambdaFunctionDefaultPolicy()
 	if err != nil {
 		return errors.Wrapf(err, "can't install app %s", appID)
@@ -146,10 +176,55 @@ func (c *Client) provisionApp(appID apps.AppID, appVersion apps.AppVersion, func
 		if err != nil {
 			return errors.Wrap(err, "can't get function name")
 		}
-		if err := c.createFunction(function.zipFile, name, function.handler, function.runtime, policyName); err != nil {
-			return errors.Wrapf(err, "can't install function for %s", appID)
+
+		if shouldUpdate {
+			if err := c.createOrUpdateFunction(function.zipFile, name, function.handler, function.runtime, policyName); err != nil {
+				return errors.Wrapf(err, "can't install function for %s", appID)
+			}
+		} else {
+			if err := c.createFunction(function.zipFile, name, function.handler, function.runtime, policyName); err != nil {
+				return errors.Wrapf(err, "can't install function for %s", appID)
+			}
 		}
 	}
+
+	return nil
+}
+
+func (c *Client) createOrUpdateFunction(zipFile io.Reader, function, handler, runtime, resource string) error {
+	if zipFile == nil || function == "" {
+		return errors.New("you must supply a zip file, function name, handler, ARN and runtime")
+	}
+
+	contents, err := ioutil.ReadAll(zipFile)
+	if err != nil {
+		return errors.Wrap(err, "could not read zip file")
+	}
+
+	_, err = c.Service().lambda.GetFunction(&lambda.GetFunctionInput{
+		FunctionName: &function,
+	})
+	if err != nil {
+		if _, ok := err.(*lambda.ResourceNotFoundException); !ok {
+			return errors.Wrap(err, "Failed go get function")
+		}
+
+		// Create function if it doesn't exist
+		return c.createFunction(zipFile, function, handler, runtime, resource)
+	}
+
+	c.logger.Info("Updating existing function", "name", function)
+
+	result, err := c.Service().lambda.UpdateFunctionCode(&lambda.UpdateFunctionCodeInput{
+		ZipFile:      contents,
+		FunctionName: &function,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to update function %v", function)
+	}
+
+	c.logger.Info(fmt.Sprintf("function named %s was updated", function), "result", result.String())
+
 	return nil
 }
 
@@ -179,10 +254,11 @@ func (c *Client) createFunction(zipFile io.Reader, function, handler, runtime, r
 	result, err := c.Service().lambda.CreateFunction(createArgs)
 	if err != nil {
 		if _, ok := err.(*lambda.ResourceConflictException); !ok {
-			return errors.Wrapf(err, "Can't create function res = %v\n", result)
+			return errors.Wrapf(err, "Can't create function. Response: %v\n", result)
 		}
 	}
-	c.logger.Info(fmt.Sprintf("function named %s was created with result - %v", function, result))
+
+	c.logger.Info(fmt.Sprintf("function named %s was created with response: %v", function, result))
 
 	return nil
 }

--- a/server/api/impl/aws/s3.go
+++ b/server/api/impl/aws/s3.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-apps/apps"
 )
 
-// S3FileDownload is used to download files from the S3
+// S3FileDownload is used to download files from the S3.
 func (c *Client) S3FileDownload(bucket, item string) ([]byte, error) {
 	var buffer aws.WriteAtBuffer
 	_, err := c.Service().s3Downloader.Download(&buffer, &s3.GetObjectInput{
@@ -27,12 +27,41 @@ func (c *Client) S3FileDownload(bucket, item string) ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
-// GetManifest returns a manifest file for an app from the S3
+// CreateBucket creates a new s3 bucket.
+func (c *Client) CreateBucket(bucket string) error {
+	_, err := c.Service().s3.CreateBucket(&s3.CreateBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to create bucket")
+	}
+
+	return nil
+}
+
+// CheckIfBucketExists return true if a bucket with the given name exists.
+// Otherwise it returns false.
+func (c *Client) CheckIfBucketExists(name string) (bool, error) {
+	buckets, err := c.Service().s3.ListBuckets(&s3.ListBucketsInput{})
+	if err != nil {
+		return false, errors.Wrap(err, "failed to list buckets")
+	}
+
+	for _, b := range buckets.Buckets {
+		if *b.Name == name {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// GetManifest returns a manifest file for an app from the S3.
 func (c *Client) GetManifest(appID apps.AppID, version apps.AppVersion) (*apps.Manifest, error) {
 	manifestFileName := fmt.Sprintf("manifest_%s_%s", appID, version)
-	data, err := c.S3FileDownload(c.appsS3Bucket, manifestFileName)
+	data, err := c.S3FileDownload(c.AppsS3Bucket, manifestFileName)
 	if err != nil {
-		return nil, errors.Wrapf(err, "can't download manifest %s/%s", c.appsS3Bucket, manifestFileName)
+		return nil, errors.Wrapf(err, "can't download manifest %s/%s", c.AppsS3Bucket, manifestFileName)
 	}
 	var manifest *apps.Manifest
 	if err := json.Unmarshal(data, &manifest); err != nil {

--- a/server/api/impl/aws/service.go
+++ b/server/api/impl/aws/service.go
@@ -18,6 +18,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager/s3manageriface"
 )
@@ -36,13 +38,14 @@ type Client struct {
 	service      *Service
 	config       *aws.Config
 	mux          *sync.Mutex
-	appsS3Bucket string
+	AppsS3Bucket string
 }
 
 // Service hold AWS clients for each service.
 type Service struct {
 	lambda       lambdaiface.LambdaAPI
 	iam          iamiface.IAMAPI
+	s3           s3iface.S3API
 	s3Downloader s3manageriface.DownloaderAPI
 }
 
@@ -59,7 +62,7 @@ func NewAWSClientWithConfig(config *aws.Config, bucket string, logger log) *Clie
 		logger:       logger,
 		config:       config,
 		mux:          &sync.Mutex{},
-		appsS3Bucket: bucket,
+		AppsS3Bucket: bucket,
 	}
 }
 
@@ -89,8 +92,9 @@ func createAWSConfig(awsAccessKeyID, awsSecretAccessKey string) *aws.Config {
 // NewService creates a new instance of Service.
 func NewService(sess *session.Session) *Service {
 	return &Service{
-		lambda:       lambda.New(sess, aws.NewConfig().WithLogLevel(aws.LogDebugWithRequestErrors)),
+		lambda:       lambda.New(sess, aws.NewConfig()),
 		iam:          iam.New(sess),
+		s3:           s3.New(sess),
 		s3Downloader: s3manager.NewDownloader(sess),
 	}
 }

--- a/server/command/install.go
+++ b/server/command/install.go
@@ -77,26 +77,3 @@ func (s *service) executeInstall(params *params) (*model.CommandResponse, error)
 		ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
 	}, nil
 }
-
-func (s *service) executeProvision(params *params) (*model.CommandResponse, error) {
-	var releaseURL string
-	var shouldUpdate bool
-	fs := pflag.NewFlagSet("", pflag.ContinueOnError)
-	fs.StringVar(&releaseURL, "url", "", "release URL")
-	fs.BoolVar(&shouldUpdate, "update", false, "Update functions if they already exist. Use with causion in production.")
-
-	err := fs.Parse(params.current)
-	if err != nil {
-		return errorOut(params, err)
-	}
-
-	err = s.api.AWS.ProvisionAppFromURL(releaseURL, shouldUpdate)
-	if err != nil {
-		return errorOut(params, err)
-	}
-
-	return &model.CommandResponse{
-		Text:         fmt.Sprintf("installed lambda functions from url %s.", releaseURL),
-		ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
-	}, nil
-}

--- a/server/command/install.go
+++ b/server/command/install.go
@@ -79,16 +79,18 @@ func (s *service) executeInstall(params *params) (*model.CommandResponse, error)
 }
 
 func (s *service) executeProvision(params *params) (*model.CommandResponse, error) {
-	releaseURL := ""
+	var releaseURL string
+	var shouldUpdate bool
 	fs := pflag.NewFlagSet("", pflag.ContinueOnError)
 	fs.StringVar(&releaseURL, "url", "", "release URL")
+	fs.BoolVar(&shouldUpdate, "update", false, "Update functions if they already exist. Use with causion in production.")
 
 	err := fs.Parse(params.current)
 	if err != nil {
 		return errorOut(params, err)
 	}
 
-	err = s.api.AWS.ProvisionApp(releaseURL)
+	err = s.api.AWS.ProvisionAppFromURL(releaseURL, shouldUpdate)
 	if err != nil {
 		return errorOut(params, err)
 	}

--- a/server/command/main.go
+++ b/server/command/main.go
@@ -25,7 +25,6 @@ func (s *service) handleMain(in *params) (*model.CommandResponse, error) {
 		"debug-install-builtin": s.executeDebugInstallBuiltinHello,
 		"debug-install-http":    s.executeDebugInstallHTTPHello,
 		"debug-install-aws":     s.executeDebugInstallAWSHello,
-		"provision":             s.executeProvision,
 		"info":                  s.executeInfo,
 		"list":                  s.executeList,
 		"install":               s.executeInstall,


### PR DESCRIPTION
#### Summary
This PR introduces `appsctl` as a tool to manage and provision apps.

The important command is `appsctl provision app` which takes an apps bundle as input and provisions it to AWS. For development purposes there is an `--update` flag that updates the function. In production, we won't be using that, but instead release a new version.

I've added some documentation to the readme.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32702

