### PR TITLE
[MM-32910] Fix app store

### DIFF
--- a/server/api/config.go
+++ b/server/api/config.go
@@ -2,14 +2,12 @@ package api
 
 import (
 	"github.com/mattermost/mattermost-server/v5/model"
-
-	"github.com/mattermost/mattermost-plugin-apps/apps"
 )
 
 // StoredConfig represents the data stored in and managed with the Mattermost
 // config.
 type StoredConfig struct {
-	Apps               map[apps.AppID]interface{}
+	Apps               map[string]interface{}
 	AWSAccessKeyID     string
 	AWSSecretAccessKey string
 }

--- a/server/api/impl/store/apps.go
+++ b/server/api/impl/store/apps.go
@@ -39,7 +39,7 @@ func (s AppStore) Get(appID apps.AppID) (*apps.App, error) {
 	if len(conf.Apps) == 0 {
 		return nil, utils.ErrNotFound
 	}
-	v := conf.Apps[appID]
+	v := conf.Apps[string(appID)]
 	if v == nil {
 		return nil, utils.ErrNotFound
 	}
@@ -51,13 +51,13 @@ func (s AppStore) Get(appID apps.AppID) (*apps.App, error) {
 func (s AppStore) Save(app *apps.App) error {
 	conf := s.conf.GetConfig()
 	if len(conf.Apps) == 0 {
-		conf.Apps = map[apps.AppID]interface{}{}
+		conf.Apps = map[string]interface{}{}
 	}
 	// do not store manifest in the config
 	app.AppID = app.Manifest.AppID
 	app.Manifest = nil
 
-	conf.Apps[app.Manifest.AppID] = app.ConfigMap()
+	conf.Apps[string(app.Manifest.AppID)] = app.ConfigMap()
 
 	// Refresh the local config immediately, do not wait for the
 	// OnConfigurationChange.
@@ -71,7 +71,7 @@ func (s AppStore) Save(app *apps.App) error {
 
 func (s AppStore) Delete(app *apps.App) error {
 	conf := s.conf.GetConfig()
-	delete(conf.Apps, app.Manifest.AppID)
+	delete(conf.Apps, string(app.Manifest.AppID))
 
 	// Refresh the local config immediately, do not wait for the
 	// OnConfigurationChange.


### PR DESCRIPTION
#### Summary
`gob` can't deal with a `map[apps.AppID]interface{}` as it's an unknown type to it. We either need to use a `[]inferface{}` or `map[string]interface{}`. I went with the latter as there are some code areas  that make use of the `map` and I wanted to keep the diff simple. Open for other suggestions.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32910

