### PR TITLE
[MM-33081] Don't modify app passed to store

### DIFF
--- a/server/api/impl/store/apps.go
+++ b/server/api/impl/store/apps.go
@@ -53,11 +53,15 @@ func (s AppStore) Save(app *apps.App) error {
 	if len(conf.Apps) == 0 {
 		conf.Apps = map[string]interface{}{}
 	}
-	// do not store manifest in the config
-	app.AppID = app.Manifest.AppID
-	app.Manifest = nil
 
-	conf.Apps[string(app.Manifest.AppID)] = app.ConfigMap()
+	// Copy app before modifying it
+	cApp := &apps.App{}
+	*cApp = *app
+	// do not store manifest in the config
+	cApp.AppID = app.Manifest.AppID
+	cApp.Manifest = nil
+
+	conf.Apps[string(cApp.AppID)] = cApp.ConfigMap()
 
 	// Refresh the local config immediately, do not wait for the
 	// OnConfigurationChange.


### PR DESCRIPTION
#### Summary
The store did modify the passed `App` and hence caused a panic upstream.

While this PR fixes the bug, I would _love_ for us to stop using pointer even if it's not needed like passing an app to the store.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33081