### PR TITLE
[MM-33083] Use HTTP request like payload to invoke lambda

### DIFF
--- a/server/api/aws.go
+++ b/server/api/aws.go
@@ -7,5 +7,5 @@ import "github.com/mattermost/mattermost-plugin-apps/apps"
 
 type AWS interface {
 	ProvisionApp(releaseURL string) error
-	InvokeLambda(appID apps.AppID, appVersion apps.AppVersion, functionName, invocationType string, request interface{}) ([]byte, error)
+	InvokeLambda(appID apps.AppID, appVersion apps.AppVersion, functionName, invocationType string, payload []byte) ([]byte, error)
 }

--- a/server/api/impl/aws/lambda.go
+++ b/server/api/impl/aws/lambda.go
@@ -4,8 +4,6 @@
 package aws
 
 import (
-	"encoding/json"
-
 	"github.com/pkg/errors"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -15,12 +13,7 @@ import (
 )
 
 // InvokeLambda runs a lambda function with specified name and returns a payload
-func (c *Client) InvokeLambda(appID apps.AppID, appVersion apps.AppVersion, functionName, invocationType string, request interface{}) ([]byte, error) {
-	payload, err := json.Marshal(request)
-	if err != nil {
-		return nil, errors.Wrap(err, "Error marshaling request payload")
-	}
-
+func (c *Client) InvokeLambda(appID apps.AppID, appVersion apps.AppVersion, functionName, invocationType string, payload []byte) ([]byte, error) {
 	name, err := getFunctionName(appID, appVersion, functionName)
 	if err != nil {
 		return nil, errors.Wrap(err, "can't get function name")
@@ -34,5 +27,6 @@ func (c *Client) InvokeLambda(appID apps.AppID, appVersion apps.AppVersion, func
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error calling function %s", name)
 	}
+
 	return result.Payload, nil
 }

--- a/server/api/impl/upstream/upawslambda/upstream.go
+++ b/server/api/impl/upstream/upawslambda/upstream.go
@@ -22,6 +22,8 @@ type Upstream struct {
 	aws *aws.Client
 }
 
+// invocationPayload is a scoped down version of
+// https://pkg.go.dev/github.com/aws/aws-lambda-go@v1.13.3/events#APIGatewayProxyRequest
 type invocationPayload struct {
 	Path       string            `json:"path"`
 	HTTPMethod string            `json:"httpMethod"`
@@ -29,6 +31,8 @@ type invocationPayload struct {
 	Body       interface{}       `json:"body"`
 }
 
+// invocationResponse is a scoped down version of
+// https://pkg.go.dev/github.com/aws/aws-lambda-go@v1.13.3/events#APIGatewayProxyResponse
 type invocationResponse struct {
 	StatusCode int    `json:"statusCode"`
 	Body       string `json:"body"`

--- a/server/api/impl/upstream/upawslambda/upstream.go
+++ b/server/api/impl/upstream/upawslambda/upstream.go
@@ -4,11 +4,14 @@
 package upawslambda
 
 import (
-	"bytes"
+	"encoding/json"
 	"io"
 	"io/ioutil"
+	"net/http"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost-plugin-apps/apps"
 	"github.com/mattermost/mattermost-plugin-apps/server/api/impl/aws"
@@ -19,6 +22,18 @@ type Upstream struct {
 	aws *aws.Client
 }
 
+type invocationPayload struct {
+	Path       string            `json:"path"`
+	HTTPMethod string            `json:"httpMethod"`
+	Headers    map[string]string `json:"headers"`
+	Body       interface{}       `json:"body"`
+}
+
+type invocationResponse struct {
+	StatusCode int    `json:"statusCode"`
+	Body       string `json:"body"`
+}
+
 func NewUpstream(app *apps.App, aws *aws.Client) *Upstream {
 	return &Upstream{
 		app: app,
@@ -27,14 +42,52 @@ func NewUpstream(app *apps.App, aws *aws.Client) *Upstream {
 }
 
 func (u *Upstream) OneWay(call *apps.Call) error {
-	_, err := u.aws.InvokeLambda(u.app.Manifest.AppID, u.app.Manifest.Version, call.URL, lambda.InvocationTypeEvent, call)
+	payload, err := CallToInvocationPayload(call)
+	if err != nil {
+		return errors.Wrap(err, "failed to covert call into invocation payload")
+	}
+
+	_, err = u.aws.InvokeLambda(u.app.Manifest.AppID, u.app.Manifest.Version, u.app.Manifest.Functions[0].Name, lambda.InvocationTypeEvent, payload)
 	return err
 }
 
 func (u *Upstream) Roundtrip(call *apps.Call) (io.ReadCloser, error) {
-	bb, err := u.aws.InvokeLambda(u.app.Manifest.AppID, u.app.Manifest.Version, call.URL, lambda.InvocationTypeRequestResponse, call)
+	payload, err := CallToInvocationPayload(call)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to covert call into invocation payload")
+	}
+
+	bb, err := u.aws.InvokeLambda(u.app.Manifest.AppID, u.app.Manifest.Version, u.app.Manifest.Functions[0].Name, lambda.InvocationTypeRequestResponse, payload)
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.NopCloser(bytes.NewReader(bb)), err
+
+	var resp invocationResponse
+
+	err = json.Unmarshal(bb, &resp)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error marshaling request payload")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("lambda invocation failed with status code %v and body %v", resp.StatusCode, resp.Body)
+	}
+
+	return ioutil.NopCloser(strings.NewReader(resp.Body)), nil
+}
+
+func CallToInvocationPayload(call *apps.Call) ([]byte, error) {
+	request := invocationPayload{
+		Path:       call.URL,
+		HTTPMethod: http.MethodPost,
+		Headers:    map[string]string{"Content-Type": "application/json"},
+		Body:       call,
+	}
+
+	payload, err := json.Marshal(request)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to marshal call into http payload")
+	}
+
+	return payload, nil
 }

--- a/server/api/impl/upstream/upawslambda/upstream.go
+++ b/server/api/impl/upstream/upawslambda/upstream.go
@@ -46,7 +46,7 @@ func NewUpstream(app *apps.App, aws *aws.Client) *Upstream {
 }
 
 func (u *Upstream) OneWay(call *apps.Call) error {
-	payload, err := CallToInvocationPayload(call)
+	payload, err := callToInvocationPayload(call)
 	if err != nil {
 		return errors.Wrap(err, "failed to covert call into invocation payload")
 	}
@@ -56,7 +56,7 @@ func (u *Upstream) OneWay(call *apps.Call) error {
 }
 
 func (u *Upstream) Roundtrip(call *apps.Call) (io.ReadCloser, error) {
-	payload, err := CallToInvocationPayload(call)
+	payload, err := callToInvocationPayload(call)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to covert call into invocation payload")
 	}
@@ -80,7 +80,7 @@ func (u *Upstream) Roundtrip(call *apps.Call) (io.ReadCloser, error) {
 	return ioutil.NopCloser(strings.NewReader(resp.Body)), nil
 }
 
-func CallToInvocationPayload(call *apps.Call) ([]byte, error) {
+func callToInvocationPayload(call *apps.Call) ([]byte, error) {
 	request := invocationPayload{
 		Path:       call.URL,
 		HTTPMethod: http.MethodPost,


### PR DESCRIPTION
#### Summary
Because the Apps expect HTTP-like requests we have to adopt the payload that is used to invoke the lambda function. The format is documented [here](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html). I didn't fill out all fields given that we only need a handful.

There is some double JSON Unmarshaling in the code that I couldn't prevent. Maybe we need to optimize that later.

Given that there is no per path mapping to function right now, all calls go to the first defined function. Hence, the PR kind of drops support for more then one function.

I've tested the PR with the Zendesk app and can confirm that it works.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33083
