### PR TITLE
[MM-33093] Improve handling when manifest is not found on S3

### DIFF
--- a/server/api/impl/admin/synchronize.go
+++ b/server/api/impl/admin/synchronize.go
@@ -47,13 +47,18 @@ func getAppsForInstallation(path, installationID string) (apps.AppVersionMap, er
 
 func (adm *Admin) populateManifests(appVersions apps.AppVersionMap) {
 	adm.store.Manifest().Cleanup()
+
 	for id, version := range appVersions {
 		manifest, err := adm.awsClient.GetManifest(id, version)
 		if err != nil {
-			// Note that we are not returning an error here.
-			adm.mm.Log.Error("can't get manifest for", "app", id, "version", version, "err", err)
+			// Note that we are not returning an error here. Instead we drop the app from the list.
+			delete(appVersions, id)
+
+			adm.mm.Log.Error("failed to get manifest", "app", id, "version", version, "err", err.Error())
+
 			continue
 		}
+
 		adm.store.Manifest().Save(manifest)
 	}
 }


### PR DESCRIPTION
#### Summary
If a listed files doesn't have a manifest in S3, it should get dropped from the list. The rest of the code base doesn't know how to handle an app without a manifest and panics.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33093