### PR TITLE
Add user agent to call context

### DIFF
--- a/apps/context.go
+++ b/apps/context.go
@@ -17,6 +17,7 @@ type Context struct {
 	RootPostID        string            `json:"root_post_id,omitempty"`
 	Props             map[string]string `json:"props,omitempty"`
 	MattermostSiteURL string            `json:"mattermost_site_url"`
+	UserAgent         string            `json:"user_agent,omitempty"`
 	ExpandedContext
 }
 

--- a/server/api/constants.go
+++ b/server/api/constants.go
@@ -45,5 +45,5 @@ const (
 	PropTeamID    = "team_id"
 	PropChannelID = "channel_id"
 	PropPostID    = "post_id"
-	PropUserAgent = "scope"
+	PropUserAgent = "user_agent_type"
 )

--- a/server/api/constants.go
+++ b/server/api/constants.go
@@ -45,4 +45,5 @@ const (
 	PropTeamID    = "team_id"
 	PropChannelID = "channel_id"
 	PropPostID    = "post_id"
+	PropUserAgent = "scope"
 )

--- a/server/http/restapi/bindings.go
+++ b/server/http/restapi/bindings.go
@@ -16,6 +16,7 @@ func (a *restapi) handleGetBindings(w http.ResponseWriter, req *http.Request, ac
 		ActingUserID:      actingUserID,
 		UserID:            actingUserID,
 		PostID:            query.Get(api.PropPostID),
+		UserAgent:         query.Get(api.PropUserAgent),
 		MattermostSiteURL: a.api.Configurator.GetConfig().MattermostSiteURL,
 	})
 	if err != nil {


### PR DESCRIPTION
#### Summary
Add user agent to call context to allow discriminating between contexts (specially for bindings, but also may be interesting for other calls).

#### Ticket Link
None

#### Related PRs
Redux: https://github.com/mattermost/mattermost-redux/pull/1379
Mobile: https://github.com/mattermost/mattermost-mobile/pull/5193