### PR TITLE
Add refresh websocket event on app install

### DIFF
--- a/server/api/constants.go
+++ b/server/api/constants.go
@@ -40,7 +40,7 @@ const (
 
 	BindingsPath = "/bindings"
 
-	WesocketEventRefreshBindings = "refresh_bindings"
+	WebsocketEventRefreshBindings = "refresh_bindings"
 )
 
 const (

--- a/server/api/constants.go
+++ b/server/api/constants.go
@@ -40,7 +40,7 @@ const (
 
 	BindingsPath = "/bindings"
 
-	WebsocketEventRefreshBindings = "refresh_bindings"
+	WebSocketEventRefreshBindings = "refresh_bindings"
 )
 
 const (

--- a/server/api/constants.go
+++ b/server/api/constants.go
@@ -39,6 +39,8 @@ const (
 	UnsubscribePath = "/unsubscribe"
 
 	BindingsPath = "/bindings"
+
+	WesocketEventRefreshBindings = "refresh_bindings"
 )
 
 const (

--- a/server/api/impl/admin/install.go
+++ b/server/api/impl/admin/install.go
@@ -70,7 +70,7 @@ func (adm *Admin) InstallApp(cc *apps.Context, sessionToken apps.SessionToken, i
 		return nil, "", errors.Wrap(resp, "install failed")
 	}
 
-	adm.mm.Frontend.PublishWebSocketEvent(api.WebsocketEventRefreshBindings, map[string]interface{}{}, &model.WebsocketBroadcast{UserId: cc.ActingUserID})
+	adm.mm.Frontend.PublishWebSocketEvent(api.WebSocketEventRefreshBindings, map[string]interface{}{}, &model.WebsocketBroadcast{UserId: cc.ActingUserID})
 	return app, resp.Markdown, nil
 }
 

--- a/server/api/impl/admin/install.go
+++ b/server/api/impl/admin/install.go
@@ -70,7 +70,7 @@ func (adm *Admin) InstallApp(cc *apps.Context, sessionToken apps.SessionToken, i
 		return nil, "", errors.Wrap(resp, "install failed")
 	}
 
-	adm.mm.Frontend.PublishWebSocketEvent(api.WesocketEventRefreshBindings, map[string]interface{}{}, &model.WebsocketBroadcast{UserId: cc.ActingUserID})
+	adm.mm.Frontend.PublishWebSocketEvent(api.WebsocketEventRefreshBindings, map[string]interface{}{}, &model.WebsocketBroadcast{UserId: cc.ActingUserID})
 	return app, resp.Markdown, nil
 }
 

--- a/server/api/impl/admin/install.go
+++ b/server/api/impl/admin/install.go
@@ -70,6 +70,7 @@ func (adm *Admin) InstallApp(cc *apps.Context, sessionToken apps.SessionToken, i
 		return nil, "", errors.Wrap(resp, "install failed")
 	}
 
+	adm.mm.Frontend.PublishWebSocketEvent(api.WesocketEventRefreshBindings, map[string]interface{}{}, &model.WebsocketBroadcast{UserId: cc.ActingUserID})
 	return app, resp.Markdown, nil
 }
 


### PR DESCRIPTION
#### Summary
When the app gets installed, send a websocket event to the user that installed the app.
There is no need to send the websocket event to all the users, since their experience will not be affected if they have to navigate to another channel to see the effects of the install (since they are not installing the app, they don't know when the app gets installed).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33129

#### Related PRs
Mobile: https://github.com/mattermost/mattermost-mobile/pull/5194
Webapp: https://github.com/mattermost/mattermost-webapp/pull/7599

