### PR TITLE
[MM-33377] Move AWS invoke credentials to env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Change your directory back to `mattermost-plugin-apps` and run the end to end te
 make test-e2e
 ```
 
+## Installing AWS Apps
+
+To install an AWS App you need to set `APPS_INVOKE_AWS_ACCESS_KEY` and `APPS_INVOKE_AWS_SECRET_KEY`. These credentials should only allow the invocation of lambda function, not the creation.
+
 ## Provisioning
 
 To provision an App to AWS you first need to store your AWS access key in an environment variable called `APPS_PROVISION_AWS_ACCESS_KEY` and the secret key in `APPS_PROVISION_AWS_SECRET_KEY`.

--- a/plugin.json
+++ b/plugin.json
@@ -13,20 +13,7 @@
     },
     "settings_schema": {
         "header": "Provide keyID and secret to the AWS account, if left empty apps will be installed in the MM cloud",
-        "settings": [
-            {
-                "key": "AWSAccessKeyID",
-                "display_name": "AWS Access Key ID",
-                "type": "text",
-                "default": ""
-            },
-            {
-                "key": "AWSSecretAccessKey",
-                "display_name": "AWS Secret Access Key",
-                "type": "text",
-                "default": ""
-            }
-        ],
-        "footer": "To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/mattermost/mattermost-plugin-apps)."
+        "footer": "To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/mattermost/mattermost-plugin-apps).",
+        "settings": []
     }
 }

--- a/server/api/config.go
+++ b/server/api/config.go
@@ -7,9 +7,7 @@ import (
 // StoredConfig represents the data stored in and managed with the Mattermost
 // config.
 type StoredConfig struct {
-	Apps               map[string]interface{}
-	AWSAccessKeyID     string
-	AWSSecretAccessKey string
+	Apps map[string]interface{}
 }
 
 type ConfigMapper interface {
@@ -18,9 +16,7 @@ type ConfigMapper interface {
 
 func (sc *StoredConfig) ConfigMap() map[string]interface{} {
 	return map[string]interface{}{
-		"Apps":               sc.Apps,
-		"AWSAccessKeyID":     sc.AWSAccessKeyID,
-		"AWSSecretAccessKey": sc.AWSSecretAccessKey,
+		"Apps": sc.Apps,
 	}
 }
 

--- a/server/api/impl/aws/service.go
+++ b/server/api/impl/aws/service.go
@@ -81,12 +81,7 @@ func NewAWSClient(awsAccessKeyID, awsSecretAccessKey string, logger log) *Client
 }
 
 func createAWSConfig(awsAccessKeyID, awsSecretAccessKey string) *aws.Config {
-	var creds *credentials.Credentials
-	if awsSecretAccessKey == "" && awsAccessKeyID == "" {
-		creds = credentials.NewEnvCredentials() // Read Mattermost cloud credentials from the environment variables
-	} else {
-		creds = credentials.NewStaticCredentials(awsAccessKeyID, awsSecretAccessKey, "")
-	}
+	creds := credentials.NewStaticCredentials(awsAccessKeyID, awsSecretAccessKey, "")
 
 	return &aws.Config{
 		Region:      aws.String(DefaultRegion),

--- a/server/api/impl/configurator/configurator.go
+++ b/server/api/impl/configurator/configurator.go
@@ -80,15 +80,6 @@ func (c *config) RefreshConfig(stored *api.StoredConfig) error {
 
 	newConfig := c.GetConfig()
 
-	prevStored := newConfig.StoredConfig
-
-	if prevStored != nil {
-		if prevStored.AWSSecretAccessKey != stored.AWSSecretAccessKey ||
-			prevStored.AWSAccessKeyID != stored.AWSAccessKeyID {
-			c.awsClient.RefreshService(stored.AWSAccessKeyID, stored.AWSSecretAccessKey)
-		}
-	}
-
 	newConfig.StoredConfig = stored
 	newConfig.MattermostSiteURL = *mattermostSiteURL
 	newConfig.MattermostSiteHostname = mattermostURL.Hostname()

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -28,24 +28,7 @@ const manifestStr = `
   "settings_schema": {
     "header": "Provide keyID and secret to the AWS account, if left empty apps will be installed in the MM cloud",
     "footer": "To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/mattermost/mattermost-plugin-apps).",
-    "settings": [
-      {
-        "key": "AWSAccessKeyID",
-        "display_name": "AWS Access Key ID",
-        "type": "text",
-        "help_text": "",
-        "placeholder": "",
-        "default": ""
-      },
-      {
-        "key": "AWSSecretAccessKey",
-        "display_name": "AWS Secret Access Key",
-        "type": "text",
-        "help_text": "",
-        "placeholder": "",
-        "default": ""
-      }
-    ]
+    "settings": []
   }
 }
 `

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	gohttp "net/http"
+	"os"
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
@@ -64,7 +65,16 @@ func (p *Plugin) OnActivate() error {
 	stored := api.StoredConfig{}
 	_ = p.mm.Configuration.LoadPluginConfiguration(&stored)
 
-	awsClient := aws.NewAWSClient(stored.AWSAccessKeyID, stored.AWSSecretAccessKey, &mm.Log)
+	accessKey := os.Getenv("APPS_INVOKE_AWS_ACCESS_KEY")
+	if accessKey == "" {
+		mm.Log.Warn("APPS_INVOKE_AWS_ACCESS_KEY is not set. AWS apps won't work.")
+	}
+	secretKey := os.Getenv("APPS_INVOKE_AWS_SECRET_KEY")
+	if secretKey == "" {
+		mm.Log.Warn("APPS_INVOKE_AWS_SECRET_KEY is not set. AWS apps won't work.")
+	}
+
+	awsClient := aws.NewAWSClient(accessKey, secretKey, &mm.Log)
 
 	conf := configurator.NewConfigurator(mm, awsClient, p.BuildConfig, botUserID)
 	_ = conf.RefreshConfig(&stored)


### PR DESCRIPTION
#### Summary
In production, these credentials will be provided by the cloud team and configured via env variables.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33377
