### PR TITLE
[MM-33128] Require Enable OAuth 2.0 Service Provider to run commands

### DIFF
--- a/server/command/service.go
+++ b/server/command/service.go
@@ -53,14 +53,22 @@ func (s *service) ExecuteCommand(pluginContext *plugin.Context, commandArgs *mod
 	if pluginContext == nil || commandArgs == nil {
 		return errorOut(params, errors.New("invalid arguments to command.Handler. Please contact your system administrator"))
 	}
+
+	enableOAuthServiceProvider := s.api.Mattermost.Configuration.GetConfig().ServiceSettings.EnableOAuthServiceProvider
+	if enableOAuthServiceProvider == nil || !*enableOAuthServiceProvider {
+		return errorOut(params, errors.Errorf("the system setting `Enable OAuth 2.0 Service Provider` need to be enabled in oder for the Apps plugin to work. Please go to %s/admin_console/integrations/integration_management and enable it.", commandArgs.SiteURL))
+	}
+
 	split := strings.Fields(commandArgs.Command)
 	if len(split) < 2 {
 		return errorOut(params, errors.New("no subcommand specified, nothing to do"))
 	}
+
 	command := split[0]
 	if command != "/"+api.CommandTrigger {
 		return errorOut(params, errors.Errorf("%q is not a supported command and should not have been invoked. Please contact your system administrator", command))
 	}
+
 	params.current = split[1:]
 
 	return s.handleMain(params)

--- a/server/command/service.go
+++ b/server/command/service.go
@@ -56,7 +56,7 @@ func (s *service) ExecuteCommand(pluginContext *plugin.Context, commandArgs *mod
 
 	enableOAuthServiceProvider := s.api.Mattermost.Configuration.GetConfig().ServiceSettings.EnableOAuthServiceProvider
 	if enableOAuthServiceProvider == nil || !*enableOAuthServiceProvider {
-		return errorOut(params, errors.Errorf("the system setting `Enable OAuth 2.0 Service Provider` need to be enabled in oder for the Apps plugin to work. Please go to %s/admin_console/integrations/integration_management and enable it.", commandArgs.SiteURL))
+		return errorOut(params, errors.Errorf("the system setting `Enable OAuth 2.0 Service Provider` need to be enabled in order for the Apps plugin to work. Please go to %s/admin_console/integrations/integration_management and enable it.", commandArgs.SiteURL))
 	}
 
 	split := strings.Fields(commandArgs.Command)


### PR DESCRIPTION
#### Summary
`Enable OAuth 2.0 Service Provider` is required the run the plugin successfully. I thought erroring  when a slash command is run was the most loudest way I could think of to make admin aware that the setting is needed. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33128