### PR TITLE
[MM-33340] Add e2e tests to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,49 @@ version: 2.1
 orbs:
   plugin-ci: mattermost/plugin-ci@volatile
 
+aliases:
+- &restore_cache
+  restore_cache:
+    key: go-mod-v1-{{ checksum "go.sum" }}
+- &save_cache
+  save_cache:
+    key: go-mod-v1-{{ checksum "go.sum" }}
+    paths:
+    - "/go/pkg/mod"
+
+jobs:
+  test-e2e-postgres11:
+    docker:
+      - image: circleci/golang:1.16.0
+      - image: circleci/postgres:11-alpine
+        environment:
+          POSTGRES_USER: mmuser
+          POSTGRES_DB: mattermost_test
+    executor:
+      name: plugin-ci/default
+    steps:
+      - run:
+          name: Waiting for Postgres to be ready
+          command: |
+            for i in `seq 1 20`;
+            do
+              nc -z localhost 5432 && echo Success && exit 0
+              echo -n .
+              sleep 1
+            done
+            echo Failed waiting for Postgres && exit 1
+      - checkout
+      - run:
+          name: Cloning mattermost-server
+          command: |
+            git clone -n https://github.com/mattermost/mattermost-server.git
+            cd mattermost-server && git checkout v5.32.1
+      - *restore_cache
+      - run:
+          name: Running e2e tests
+          command: MM_SERVER_PATH=$(pwd)/mattermost-server make test-e2e
+      - *save_cache
+
 workflows:
   version: 2
   nightly:
@@ -16,6 +59,7 @@ workflows:
     jobs:
       - plugin-ci/lint
       - plugin-ci/test
+      - test-e2e-postgres11
       - plugin-ci/build
   ci:
     jobs:
@@ -24,6 +68,10 @@ workflows:
             tags:
               only: /^v.*/
       - plugin-ci/coverage:
+          filters:
+            tags:
+              only: /^v.*/
+      - test-e2e-postgres11:
           filters:
             tags:
               only: /^v.*/
@@ -39,6 +87,7 @@ workflows:
           requires:
             - plugin-ci/lint
             - plugin-ci/coverage
+            - test-e2e-postgres11
             - plugin-ci/build
       - plugin-ci/deploy-release-github:
           filters:
@@ -50,4 +99,5 @@ workflows:
           requires:
             - plugin-ci/lint
             - plugin-ci/coverage
+            - test-e2e-postgres11
             - plugin-ci/build

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@ dist/
 
 # Jetbrains
 .idea/
+
+# e2e test aux output
+/server/http/restapi/mattermost.log
+/server/http/restapi/notifications.log
+/server/http/restapi/data/

--- a/Makefile
+++ b/Makefile
@@ -247,9 +247,9 @@ ifneq ($(HAS_WEBAPP),)
 endif
 
 .PHONY: test-e2e
-test-e2e:
+test-e2e: dist
 	@echo Running e2e tests
-	MM_SERVER_PATH=${MM_SERVER_PATH} $(GO) test -v $(GO_TEST_FLAGS) -tags=e2e $(GO_PACKAGES)
+	PLUGIN_BUNDLE=$(shell pwd)/dist/$(BUNDLE_NAME) MM_SERVER_PATH=${MM_SERVER_PATH} $(GO) test -v $(GO_TEST_FLAGS) -tags=e2e $(GO_PACKAGES)
 
 ## Creates a coverage report for the server code.
 .PHONY: coverage

--- a/server/http/restapi/restapitestlib.go
+++ b/server/http/restapi/restapitestlib.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/mattermost/mattermost-server/v5/api4"
@@ -80,11 +79,11 @@ func SetupPP(th *TestHelper, t testing.TB) {
 		return
 	}
 
-	basePath := os.Getenv("MM_SERVER_PATH")
-	testPluginPath := filepath.Join(basePath, model.PLUGIN_SETTINGS_DEFAULT_DIRECTORY, pluginID+".tar.gz")
+	bundle := os.Getenv("PLUGIN_BUNDLE")
+	require.NotEmpty(t, bundle, "PLUGIN_BUNDLE is not set, please run `make test-e2e`")
 
 	// Install the PP and enable it
-	pluginBytes, err := ioutil.ReadFile(testPluginPath)
+	pluginBytes, err := ioutil.ReadFile(bundle)
 	require.NoError(t, err)
 	require.NotNil(t, pluginBytes)
 


### PR DESCRIPTION
#### Summary
To ensure the go E2E tests are validated on every change, this PR adds them to circleCI. While most of the pipeline is straight forward, one noticeable things is that it does clone `mattermost-server` to ensure the server find the translation files and start.

The PR is based on https://github.com/mattermost/mattermost-plugin-apps/pull/84. The specific changes are in https://github.com/mattermost/mattermost-plugin-apps/commit/419e4b5b5773c37e62fe9f9afb28a1f765dd4d4c.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33340
