### PR TITLE
Revert "[MM-33340] Add e2e tests to CI (#92)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,49 +3,6 @@ version: 2.1
 orbs:
   plugin-ci: mattermost/plugin-ci@volatile
 
-aliases:
-- &restore_cache
-  restore_cache:
-    key: go-mod-v1-{{ checksum "go.sum" }}
-- &save_cache
-  save_cache:
-    key: go-mod-v1-{{ checksum "go.sum" }}
-    paths:
-    - "/go/pkg/mod"
-
-jobs:
-  test-e2e-postgres11:
-    docker:
-      - image: circleci/golang:1.16.0
-      - image: circleci/postgres:11-alpine
-        environment:
-          POSTGRES_USER: mmuser
-          POSTGRES_DB: mattermost_test
-    executor:
-      name: plugin-ci/default
-    steps:
-      - run:
-          name: Waiting for Postgres to be ready
-          command: |
-            for i in `seq 1 20`;
-            do
-              nc -z localhost 5432 && echo Success && exit 0
-              echo -n .
-              sleep 1
-            done
-            echo Failed waiting for Postgres && exit 1
-      - checkout
-      - run:
-          name: Cloning mattermost-server
-          command: |
-            git clone -n https://github.com/mattermost/mattermost-server.git
-            cd mattermost-server && git checkout v5.32.1
-      - *restore_cache
-      - run:
-          name: Running e2e tests
-          command: MM_SERVER_PATH=$(pwd)/mattermost-server make test-e2e
-      - *save_cache
-
 workflows:
   version: 2
   nightly:
@@ -59,7 +16,6 @@ workflows:
     jobs:
       - plugin-ci/lint
       - plugin-ci/test
-      - test-e2e-postgres11
       - plugin-ci/build
   ci:
     jobs:
@@ -68,10 +24,6 @@ workflows:
             tags:
               only: /^v.*/
       - plugin-ci/coverage:
-          filters:
-            tags:
-              only: /^v.*/
-      - test-e2e-postgres11:
           filters:
             tags:
               only: /^v.*/
@@ -87,7 +39,6 @@ workflows:
           requires:
             - plugin-ci/lint
             - plugin-ci/coverage
-            - test-e2e-postgres11
             - plugin-ci/build
       - plugin-ci/deploy-release-github:
           filters:
@@ -99,5 +50,4 @@ workflows:
           requires:
             - plugin-ci/lint
             - plugin-ci/coverage
-            - test-e2e-postgres11
             - plugin-ci/build

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,3 @@ dist/
 
 # Jetbrains
 .idea/
-
-# e2e test aux output
-/server/http/restapi/mattermost.log
-/server/http/restapi/notifications.log
-/server/http/restapi/data/

--- a/Makefile
+++ b/Makefile
@@ -247,9 +247,9 @@ ifneq ($(HAS_WEBAPP),)
 endif
 
 .PHONY: test-e2e
-test-e2e: dist
+test-e2e:
 	@echo Running e2e tests
-	PLUGIN_BUNDLE=$(shell pwd)/dist/$(BUNDLE_NAME) MM_SERVER_PATH=${MM_SERVER_PATH} $(GO) test -v $(GO_TEST_FLAGS) -tags=e2e $(GO_PACKAGES)
+	MM_SERVER_PATH=${MM_SERVER_PATH} $(GO) test -v $(GO_TEST_FLAGS) -tags=e2e $(GO_PACKAGES)
 
 ## Creates a coverage report for the server code.
 .PHONY: coverage

--- a/server/http/restapi/restapitestlib.go
+++ b/server/http/restapi/restapitestlib.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/mattermost/mattermost-server/v5/api4"
@@ -79,11 +80,11 @@ func SetupPP(th *TestHelper, t testing.TB) {
 		return
 	}
 
-	bundle := os.Getenv("PLUGIN_BUNDLE")
-	require.NotEmpty(t, bundle, "PLUGIN_BUNDLE is not set, please run `make test-e2e`")
+	basePath := os.Getenv("MM_SERVER_PATH")
+	testPluginPath := filepath.Join(basePath, model.PLUGIN_SETTINGS_DEFAULT_DIRECTORY, pluginID+".tar.gz")
 
 	// Install the PP and enable it
-	pluginBytes, err := ioutil.ReadFile(bundle)
+	pluginBytes, err := ioutil.ReadFile(testPluginPath)
 	require.NoError(t, err)
 	require.NotNil(t, pluginBytes)
 


### PR DESCRIPTION
#### Summary
This reverts commit a800fc3cad661000c7c4b8d0b960b76fe445a9f6 as 'master` is broken due to it.


#### Ticket Link
Follow up on https://github.com/mattermost/mattermost-plugin-apps/pull/92

