### PR TITLE
Fix flaky bindings test

### DIFF
--- a/server/proxy/bindings_test.go
+++ b/server/proxy/bindings_test.go
@@ -275,6 +275,7 @@ func TestGetBindingsGrantedLocations(t *testing.T) {
 				Manifest: apps.Manifest{
 					AppID:              apps.AppID("app1"),
 					AppType:            apps.AppTypeBuiltin,
+					DisplayName:        "App 1",
 					RequestedLocations: tc.locations,
 				},
 				GrantedLocations: tc.locations,
@@ -303,8 +304,9 @@ func TestGetBindingsCommands(t *testing.T) {
 		{
 			app: &apps.App{
 				Manifest: apps.Manifest{
-					AppID:   apps.AppID("app1"),
-					AppType: apps.AppTypeBuiltin,
+					AppID:       apps.AppID("app1"),
+					AppType:     apps.AppTypeBuiltin,
+					DisplayName: "App 1",
 				},
 				GrantedLocations: apps.Locations{
 					apps.LocationChannelHeader,
@@ -366,8 +368,9 @@ func TestGetBindingsCommands(t *testing.T) {
 		{
 			app: &apps.App{
 				Manifest: apps.Manifest{
-					AppID:   apps.AppID("app2"),
-					AppType: apps.AppTypeBuiltin,
+					AppID:       apps.AppID("app2"),
+					AppType:     apps.AppTypeBuiltin,
+					DisplayName: "App 2",
 				},
 				GrantedLocations: apps.Locations{
 					apps.LocationChannelHeader,
@@ -492,8 +495,9 @@ func TestDuplicateCommand(t *testing.T) {
 		{
 			app: &apps.App{
 				Manifest: apps.Manifest{
-					AppID:   apps.AppID("app1"),
-					AppType: apps.AppTypeBuiltin,
+					AppID:       apps.AppID("app1"),
+					AppType:     apps.AppTypeBuiltin,
+					DisplayName: "App 1",
 				},
 				GrantedLocations: apps.Locations{
 					apps.LocationCommand,


### PR DESCRIPTION
There is a reordering occurring in the line below, that relies on the display name. This PR adds the display name to the tests to make the order deterministic.

https://github.com/mattermost/mattermost-plugin-apps/blob/e818ca3a03559a961aa4aca056fb5bb196bd7bab/server/proxy/bindings.go#L36-L37

https://github.com/mattermost/mattermost-plugin-apps/blob/e818ca3a03559a961aa4aca056fb5bb196bd7bab/server/store/apps.go#L121
