### PR TITLE
Fix debug add manifest command errors

### DIFF
--- a/server/command/debug.go
+++ b/server/command/debug.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 
 	"github.com/mattermost/mattermost-server/v5/model"
+	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 
 	"github.com/mattermost/mattermost-plugin-apps/apps"
@@ -37,9 +38,13 @@ func (s *service) executeDebugAddManifest(params *params) (*model.CommandRespons
 		return errorOut(params, err)
 	}
 
+	if manifestURL == "" {
+		return errorOut(params, errors.New("you must add a `--url`"))
+	}
+
 	data, err := httputils.GetFromURL(manifestURL)
 	if err != nil {
-		return nil, err
+		return errorOut(params, err)
 	}
 	m := apps.Manifest{}
 	err = json.Unmarshal(data, &m)


### PR DESCRIPTION
#### Summary
Add Manifest used to give weird errors like "there is no command with trigger /apps". Now it shows the correct errors.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34074