### PR TITLE
Remove io/ioutil

### DIFF
--- a/apps/mmclient/mattermost_client_pp.go
+++ b/apps/mmclient/mattermost_client_pp.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -182,7 +181,7 @@ func interfaceFromJSON(data io.Reader) interface{} {
 
 func (c *ClientPP) closeBody(r *http.Response) {
 	if r.Body != nil {
-		_, _ = io.Copy(ioutil.Discard, r.Body)
+		_, _ = io.Copy(io.Discard, r.Body)
 		_ = r.Body.Close()
 	}
 }

--- a/aws/lambda.go
+++ b/aws/lambda.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/lambda"
@@ -38,7 +37,7 @@ func (c *client) CreateLambda(zipFile io.Reader, function, handler, runtime, res
 		return errors.Errorf("you must supply a zip file, function name, handler, ARN and runtime - %p %s %s %s %s", zipFile, function, handler, resource, runtime)
 	}
 
-	contents, err := ioutil.ReadAll(zipFile)
+	contents, err := io.ReadAll(zipFile)
 	if err != nil {
 		return errors.Wrap(err, "could not read zip file")
 	}
@@ -82,7 +81,7 @@ func (c *client) CreateOrUpdateLambda(zipFile io.Reader, function, handler, runt
 		return c.CreateLambda(zipFile, function, handler, runtime, resource)
 	}
 
-	contents, err := ioutil.ReadAll(zipFile)
+	contents, err := io.ReadAll(zipFile)
 	if err != nil {
 		return errors.Wrap(err, "could not read zip file")
 	}

--- a/aws/provision_data.go
+++ b/aws/provision_data.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -51,7 +50,7 @@ func GetProvisionDataFromFile(path string, log Logger) (*ProvisionData, error) {
 		return nil, errors.Wrapf(err, "can't read file from  path %s", path)
 	}
 
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	if err != nil {
 		return nil, errors.Wrap(err, "can't read file")
 	}
@@ -79,7 +78,7 @@ func getProvisionData(b []byte, log Logger) (*ProvisionData, error) {
 			}
 			defer manifestFile.Close()
 
-			data, err := ioutil.ReadAll(manifestFile)
+			data, err := io.ReadAll(manifestFile)
 			if err != nil {
 				return nil, errors.Wrap(err, "can't read manifest.json file")
 			}

--- a/server/examples/go/hello/builtin_hello/helloapp.go
+++ b/server/examples/go/hello/builtin_hello/helloapp.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -93,7 +92,7 @@ func (h *helloapp) Roundtrip(c *apps.CallRequest, _ bool) (io.ReadCloser, error)
 	if err != nil {
 		return nil, err
 	}
-	return ioutil.NopCloser(bytes.NewReader(bb)), nil
+	return io.NopCloser(bytes.NewReader(bb)), nil
 }
 
 func (h *helloapp) GetStatic(path string) (io.ReadCloser, int, error) {

--- a/server/http/restapi/restapitestlib.go
+++ b/server/http/restapi/restapitestlib.go
@@ -7,7 +7,6 @@ package restapi
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -86,7 +85,7 @@ func SetupPP(th *TestHelper, t testing.TB) {
 	require.NotEmpty(t, os.Getenv("MM_SERVER_PATH"), "MM_SERVER_PATH is not set, please set it to the path of your mattermost-server clone")
 
 	// Install the PP and enable it
-	pluginBytes, err := ioutil.ReadFile(bundle)
+	pluginBytes, err := os.ReadFile(bundle)
 	require.NoError(t, err)
 	require.NotNil(t, pluginBytes)
 

--- a/server/proxy/bindings_test.go
+++ b/server/proxy/bindings_test.go
@@ -6,7 +6,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -609,7 +609,7 @@ func newTestProxyForBindings(testData []bindingTestData, ctrl *gomock.Controller
 			Data: test.bindings,
 		}
 		bb, _ := json.Marshal(cr)
-		reader := ioutil.NopCloser(bytes.NewReader(bb))
+		reader := io.NopCloser(bytes.NewReader(bb))
 
 		up := mock_upstream.NewMockUpstream(ctrl)
 		up.EXPECT().Roundtrip(gomock.Any(), gomock.Any()).Return(reader, nil)

--- a/server/store/manifest.go
+++ b/server/store/manifest.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -85,7 +84,7 @@ func (s *manifestStore) initGlobal(awscli aws.Client, bucket string, manifestsFi
 		case len(parts) == 2 && parts[0] == "s3":
 			data, err = s.getFromS3(awscli, bucket, appID, apps.AppVersion(parts[1]))
 		case len(parts) == 2 && parts[0] == "file":
-			data, err = ioutil.ReadFile(filepath.Join(assetPath, parts[1]))
+			data, err = os.ReadFile(filepath.Join(assetPath, parts[1]))
 		case len(parts) == 2 && (parts[0] == "http" || parts[0] == "https"):
 			data, err = httputils.GetFromURL(loc)
 		default:

--- a/server/utils/httputils/limited_readcloser_test.go
+++ b/server/utils/httputils/limited_readcloser_test.go
@@ -6,7 +6,6 @@ package httputils
 
 import (
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -16,7 +15,7 @@ import (
 )
 
 func TestLimitReadCloser(t *testing.T) {
-	inner := ioutil.NopCloser(strings.NewReader("01234567890"))
+	inner := io.NopCloser(strings.NewReader("01234567890"))
 
 	totalRead := utils.ByteSize(0)
 	r := &LimitReadCloser{

--- a/server/utils/httputils/utils.go
+++ b/server/utils/httputils/utils.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -95,7 +94,7 @@ func LimitReadAll(in io.Reader, limit int64) ([]byte, error) {
 	if in == nil {
 		return []byte{}, nil
 	}
-	return ioutil.ReadAll(&io.LimitedReader{R: in, N: limit})
+	return io.ReadAll(&io.LimitedReader{R: in, N: limit})
 }
 
 func ProcessResponseError(w http.ResponseWriter, resp *http.Response, err error) bool {
@@ -119,7 +118,7 @@ func GetFromURL(url string) ([]byte, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return ioutil.ReadAll(resp.Body)
+	return io.ReadAll(resp.Body)
 }
 
 func CheckAuthorized(mm *pluginapi.Client, f func(_ http.ResponseWriter, _ *http.Request, actingUserID, sessionToken string)) http.HandlerFunc {


### PR DESCRIPTION
#### Summary
`io/ioutil` has been deprecated in go 1.16 (https://golang.org/doc/go1.16#ioutil). This PR drops all references to `io/ioutil`.


#### Ticket Link
None
