### PR TITLE
[MM-33852] Fan out bindings requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.36.15
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/golang/mock v1.5.0
+	github.com/google/go-cmp v0.5.5
 	github.com/gorilla/mux v1.8.0
 	github.com/mattermost/mattermost-plugin-api v0.0.15-0.20210303034931-22355254f0ea
 	github.com/mattermost/mattermost-server/v5 v5.3.2-0.20210120031517-5a7759f4d63b

--- a/server/proxy/bindings.go
+++ b/server/proxy/bindings.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"encoding/json"
+	"sync"
 
 	"github.com/mattermost/mattermost-plugin-apps/apps"
 	"github.com/mattermost/mattermost-plugin-apps/server/store"
@@ -36,47 +37,76 @@ func mergeBindings(bb1, bb2 []*apps.Binding) []*apps.Binding {
 func (p *Proxy) GetBindings(debugSessionToken apps.SessionToken, cc *apps.Context) ([]*apps.Binding, error) {
 	allApps := store.SortApps(p.store.App.AsMap())
 
-	all := []*apps.Binding{}
-	for _, app := range allApps {
-		if !p.AppIsEnabled(app) {
-			continue
-		}
-		appID := app.AppID
-		appCC := *cc
-		appCC.AppID = appID
-		appCC.BotAccessToken = app.BotAccessToken
+	all := make([][]*apps.Binding, len(allApps))
+	var wg sync.WaitGroup
 
-		// TODO PERF: Add caching
-		// TODO PERF: Fan out the calls, wait for all to complete
-		bindingsCall := apps.DefaultBindingsCall.WithOverrides(app.Bindings)
-		bindingsRequest := &apps.CallRequest{
-			Call:    *bindingsCall,
-			Context: &appCC,
-		}
+	for i, app := range allApps {
+		wg.Add(1)
 
-		resp := p.Call(debugSessionToken, bindingsRequest)
-		if resp == nil || resp.Type != apps.CallResponseTypeOK {
-			// TODO Log error (chance to flood the logs)
-			// p.mm.Log.Debug("Response is nil or unexpected type.")
-			// if resp != nil && resp.Type == apps.CallResponseTypeError {
-			// 	p.mm.Log.Debug("Error getting bindings. Error: " + resp.Error())
-			// }
-			continue
-		}
+		go func(debugSessionToken apps.SessionToken, cc *apps.Context, app *apps.App, i int) {
+			defer wg.Done()
 
-		var bindings = []*apps.Binding{}
-		b, _ := json.Marshal(resp.Data)
-		err := json.Unmarshal(b, &bindings)
-		if err != nil {
-			// TODO Log error (chance to flood the logs)
-			// p.mm.Log.Debug("Bindings are not of the right type.")
-			continue
-		}
+			bindings, err := p.GetBindingsForApp(debugSessionToken, cc, app)
+			if err != nil {
+				p.mm.Log.Debug("Failed to get binding for app", "error", err.Error(), "appID", app.AppID)
+				return
+			}
 
-		all = mergeBindings(all, p.scanAppBindings(app, bindings, ""))
+			all[i] = bindings
+		}(debugSessionToken, cc, app, i)
 	}
 
-	return all, nil
+	wg.Wait()
+
+	ret := []*apps.Binding{}
+	for _, b := range all {
+		ret = mergeBindings(ret, b)
+	}
+
+	return ret, nil
+}
+
+// GetBindingsForApp fetches bindings for a specific apps.
+// We should avoid unnecessary logging here as this route is called very often.
+func (p *Proxy) GetBindingsForApp(debugSessionToken apps.SessionToken, cc *apps.Context, app *apps.App) ([]*apps.Binding, error) {
+	if !p.AppIsEnabled(app) {
+		return nil, nil
+	}
+
+	appID := app.AppID
+	appCC := *cc
+	appCC.AppID = appID
+	appCC.BotAccessToken = app.BotAccessToken
+
+	// TODO PERF: Add caching
+	bindingsCall := apps.DefaultBindingsCall.WithOverrides(app.Bindings)
+	bindingsRequest := &apps.CallRequest{
+		Call:    *bindingsCall,
+		Context: &appCC,
+	}
+
+	resp := p.Call(debugSessionToken, bindingsRequest)
+	if resp == nil || resp.Type != apps.CallResponseTypeOK {
+		// TODO Log error (chance to flood the logs)
+		// p.mm.Log.Debug("Response is nil or unexpected type.")
+		// if resp != nil && resp.Type == apps.CallResponseTypeError {
+		// 	p.mm.Log.Debug("Error getting bindings. Error: " + resp.Error())
+		// }
+		return nil, nil
+	}
+
+	var bindings = []*apps.Binding{}
+	b, _ := json.Marshal(resp.Data)
+	err := json.Unmarshal(b, &bindings)
+	if err != nil {
+		// TODO Log error (chance to flood the logs)
+		// p.mm.Log.Debug("Bindings are not of the right type.")
+		return nil, nil
+	}
+
+	bindings = p.scanAppBindings(app, bindings, "")
+
+	return bindings, nil
 }
 
 // scanAppBindings removes bindings to locations that have not been granted to

--- a/server/proxy/bindings_test.go
+++ b/server/proxy/bindings_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -192,7 +194,7 @@ func TestMergeBindings(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			out := mergeBindings(tc.bb1, tc.bb2)
-			require.EqualValues(t, tc.expected, out)
+			EqualBindings(t, tc.expected, out)
 		})
 	}
 }
@@ -486,7 +488,7 @@ func TestGetBindingsCommands(t *testing.T) {
 	cc := &apps.Context{}
 	out, err := proxy.GetBindings("", cc)
 	require.NoError(t, err)
-	require.EqualValues(t, expected, out)
+	EqualBindings(t, expected, out)
 }
 
 func TestDuplicateCommand(t *testing.T) {
@@ -580,7 +582,7 @@ func TestDuplicateCommand(t *testing.T) {
 	cc := &apps.Context{}
 	out, err := proxy.GetBindings("", cc)
 	require.NoError(t, err)
-	require.EqualValues(t, expected, out)
+	EqualBindings(t, expected, out)
 }
 
 func newTestProxyForBindings(testData []bindingTestData, ctrl *gomock.Controller) *Proxy {
@@ -627,4 +629,18 @@ func newTestProxyForBindings(testData []bindingTestData, ctrl *gomock.Controller
 	}
 
 	return p
+}
+
+// EqualBindings asserts that two slices of bindings are equal ignoring the order of the elements.
+// If there are duplicate elements, the number of appearances of each of them in both lists should match.
+//
+// EqualBindings calls t.Fail if the elements not match.
+func EqualBindings(t *testing.T, expected, actual []*apps.Binding) {
+	opt := cmpopts.SortSlices(func(a *apps.Binding, b *apps.Binding) bool {
+		return a.AppID < b.AppID
+	})
+
+	if diff := cmp.Diff(expected, actual, opt); diff != "" {
+		t.Errorf("Bindings mismatch (-expected +actual):\n%s", diff)
+	}
 }


### PR DESCRIPTION
#### Summary
To improve performance when fetching the bindings this PR fans out the request reducing the time from `O(n)` to `O(1)`.

I've also added a `EqualBindings` method that orders two bindings before comparing them. This is needed because the order of the bindings is not longer deterministic. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33852
