### PR TITLE
[MM-33020] Make app ID validation more strict

### DIFF
--- a/apps/app.go
+++ b/apps/app.go
@@ -68,7 +68,7 @@ type ListedApp struct {
 
 const (
 	MinAppIDLength = 3
-	MaxAppIDLength = 25
+	MaxAppIDLength = 32
 )
 
 func (id AppID) IsValid() error {

--- a/apps/app.go
+++ b/apps/app.go
@@ -66,11 +66,18 @@ type ListedApp struct {
 	Labels    []model.MarketplaceLabel `json:"labels,omitempty"`
 }
 
-const MaxAppID = 32
+const (
+	MinAppIDLength = 3
+	MaxAppIDLength = 25
+)
 
 func (id AppID) IsValid() error {
-	if len(id) > MaxAppID {
-		return errors.Errorf("appID %s too long, should be %d bytes", id, MaxAppID)
+	if len(id) < MinAppIDLength {
+		return errors.Errorf("appID %s too short, should be %d bytes", id, MinAppIDLength)
+	}
+
+	if len(id) > MaxAppIDLength {
+		return errors.Errorf("appID %s too long, should be %d bytes", id, MaxAppIDLength)
 	}
 
 	for _, c := range id {

--- a/apps/app_test.go
+++ b/apps/app_test.go
@@ -10,19 +10,19 @@ func TestAppIDIsValid(t *testing.T) {
 	t.Parallel()
 
 	for id, valid := range map[string]bool{
-		"":                           false,
-		"a":                          false,
-		"ab":                         false,
-		"abc":                        true,
-		"abcdefghijklmnopqrstuvwxy":  true,
-		"abcdefghijklmnopqrstuvwxyz": false,
-		"../path":                    false,
-		"/etc/passwd":                false,
-		"com.mattermost.app-0.9":     true,
-		"CAPS-ARE-FINE":              true,
-		"....DOTS.ALSO.......":       true,
-		"----SLASHES-ALSO----":       true,
-		"___AND_UNDERSCORES____":     true,
+		"":                                  false,
+		"a":                                 false,
+		"ab":                                false,
+		"abc":                               true,
+		"abcdefghijklmnopqrstuvwxyzabcdef":  true,
+		"abcdefghijklmnopqrstuvwxyzabcdefg": false,
+		"../path":                           false,
+		"/etc/passwd":                       false,
+		"com.mattermost.app-0.9":            true,
+		"CAPS-ARE-FINE":                     true,
+		"....DOTS.ALSO.......":              true,
+		"----SLASHES-ALSO----":              true,
+		"___AND_UNDERSCORES____":            true,
 	} {
 		t.Run(id, func(t *testing.T) {
 			err := AppID(id).IsValid()

--- a/apps/app_test.go
+++ b/apps/app_test.go
@@ -1,0 +1,36 @@
+package apps
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppIDIsValid(t *testing.T) {
+	t.Parallel()
+
+	for id, valid := range map[string]bool{
+		"":                           false,
+		"a":                          false,
+		"ab":                         false,
+		"abc":                        true,
+		"abcdefghijklmnopqrstuvwxy":  true,
+		"abcdefghijklmnopqrstuvwxyz": false,
+		"../path":                    false,
+		"/etc/passwd":                false,
+		"com.mattermost.app-0.9":     true,
+		"CAPS-ARE-FINE":              true,
+		"....DOTS.ALSO.......":       true,
+		"----SLASHES-ALSO----":       true,
+		"___AND_UNDERSCORES____":     true,
+	} {
+		t.Run(id, func(t *testing.T) {
+			err := AppID(id).IsValid()
+			if valid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}

--- a/apps/manifest.go
+++ b/apps/manifest.go
@@ -9,7 +9,7 @@ import (
 
 type Manifest struct {
 	// The AppID is a globally unique identifier that represents your app. IDs must be at least
-	// 3 characters, at most 20 characters and must contain only alphanumeric characters, dashes, underscores and periods.
+	// 3 characters, at most 32 characters and must contain only alphanumeric characters, dashes, underscores and periods.
 	AppID   AppID      `json:"app_id"`
 	AppType AppType    `json:"app_type"`
 	Version AppVersion `json:"version"`

--- a/apps/manifest.go
+++ b/apps/manifest.go
@@ -8,6 +8,8 @@ import (
 )
 
 type Manifest struct {
+	// The AppID is a globally unique identifier that represents your app. IDs must be at least
+	// 3 characters, at most 20 characters and must contain only alphanumeric characters, dashes, underscores and periods.
 	AppID   AppID      `json:"app_id"`
 	AppType AppType    `json:"app_type"`
 	Version AppVersion `json:"version"`
@@ -122,9 +124,11 @@ func ManifestFromJSON(data []byte) (*Manifest, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	err = m.IsValid()
 	if err != nil {
 		return nil, err
 	}
+
 	return &m, nil
 }

--- a/server/command/debug.go
+++ b/server/command/debug.go
@@ -4,8 +4,6 @@
 package command
 
 import (
-	"encoding/json"
-
 	"github.com/mattermost/mattermost-server/v5/model"
 	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
@@ -48,13 +46,13 @@ func (s *service) executeDebugAddManifest(params *params) (*model.CommandRespons
 	if err != nil {
 		return errorOut(params, err)
 	}
-	m := apps.Manifest{}
-	err = json.Unmarshal(data, &m)
+
+	m, err := apps.ManifestFromJSON(data)
 	if err != nil {
 		return errorOut(params, err)
 	}
 
-	out, err := s.proxy.AddLocalManifest(params.commandArgs.UserId, apps.SessionToken(params.commandArgs.Session.Token), &m)
+	out, err := s.proxy.AddLocalManifest(params.commandArgs.UserId, apps.SessionToken(params.commandArgs.Session.Token), m)
 	if err != nil {
 		return errorOut(params, err)
 	}


### PR DESCRIPTION
### Summary
Given that we use app IDs in the store where key length is limited we should put a stricter limit on the length. Also, 3 characters is now the minimum limit.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33020

