### PR TITLE
Drop term "Cloud Apps"

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,8 +1,8 @@
 {
     "id": "com.mattermost.apps",
-    "name": "Cloud Apps",
-    "description": "Cloud Apps Registry and API proxy.",
-    "version": "0.1.0",
+    "name": "Apps",
+    "description": "Apps Registry and API proxy.",
+    "version": "0.2.0",
     "min_server_version": "5.26.0",
     "server": {
         "executables": {
@@ -12,7 +12,7 @@
         }
     },
     "settings_schema": {
-        "header": "Provide keyID and secret to the AWS account, if left empty apps will be installed in the MM cloud",
+        "header": "",
         "footer": "To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/mattermost/mattermost-plugin-apps).",
         "settings": []
     }

--- a/server/command/info.go
+++ b/server/command/info.go
@@ -12,7 +12,7 @@ import (
 
 func (s *service) executeInfo(params *params) (*model.CommandResponse, error) {
 	conf := s.conf.GetConfig()
-	resp := md.Markdownf("Mattermost Cloud Apps plugin version: %s, "+
+	resp := md.Markdownf("Mattermost Apps plugin version: %s, "+
 		"[%s](https://github.com/mattermost/%s/commit/%s), built %s\n",
 		conf.Version,
 		conf.BuildHashShort,

--- a/server/command/service.go
+++ b/server/command/service.go
@@ -72,7 +72,7 @@ func MakeService(mm *pluginapi.Client, configService config.Service, proxy proxy
 	err := mm.SlashCommand.Register(&model.Command{
 		Trigger:          config.CommandTrigger,
 		AutoComplete:     true,
-		AutoCompleteDesc: "Manage Cloud Apps",
+		AutoCompleteDesc: "Manage Apps",
 		AutoCompleteHint: fmt.Sprintf("Usage: `/%s info`.", config.CommandTrigger),
 		AutocompleteData: autoComplete,
 	})

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -13,9 +13,9 @@ var manifest *model.Manifest
 const manifestStr = `
 {
   "id": "com.mattermost.apps",
-  "name": "Cloud Apps",
-  "description": "Cloud Apps Registry and API proxy.",
-  "version": "0.1.0",
+  "name": "Apps",
+  "description": "Apps Registry and API proxy.",
+  "version": "0.2.0",
   "min_server_version": "5.26.0",
   "server": {
     "executables": {
@@ -26,7 +26,7 @@ const manifestStr = `
     "executable": ""
   },
   "settings_schema": {
-    "header": "Provide keyID and secret to the AWS account, if left empty apps will be installed in the MM cloud",
+    "header": "",
     "footer": "To report an issue, make a suggestion or a contribution, [check the repository](https://github.com/mattermost/mattermost-plugin-apps).",
     "settings": []
   }


### PR DESCRIPTION
#### Summary
As discussed offline the term `Cloud Apps` should not longer be used and `Apps` is the sole term.

#### Ticket Link
https://community-daily.mattermost.com/core/pl/3qzqjrye33gofez1kdoustqmzy