### PR TITLE
Add explicit app permission type for bot posting in all channels

### DIFF
--- a/apps/permissions.go
+++ b/apps/permissions.go
@@ -20,6 +20,13 @@ const (
 	// receive permissions to any resources, need to be added explicitly.
 	PermissionActAsBot Permission = "act_as_bot"
 
+	// PermissionPostAllAsBot means that the Bot User will be assigned the role
+	// of `system_post_all`. This makes it so the bot can create posts in direct message
+	// and group message channels. Without this permission, the bot must be explicitly added to
+	// public and private channels by the app, and the bot would not be able to create posts
+	// in direct message or group message channels.
+	PermissionPostAllAsBot Permission = "post_all_as_bot"
+
 	// PermissionActAsUser means that the app is allowed to connect users'
 	// OAuth2 accounts, and then use user API tokens.
 	PermissionActAsUser Permission = "act_as_user"

--- a/server/proxy/install.go
+++ b/server/proxy/install.go
@@ -183,7 +183,7 @@ func (p *Proxy) ensureBot(manifest *apps.Manifest, actingUserID string, client *
 			return nil, nil, errors.Errorf("failed to get bot user, status code = %v", response.StatusCode)
 		}
 
-		if !strings.Contains(user.Roles, model.SYSTEM_POST_ALL_ROLE_ID) {
+		if manifest.RequestedPermissions.Contains(apps.PermissionPostAllAsBot) && !strings.Contains(user.Roles, model.SYSTEM_POST_ALL_ROLE_ID) {
 			newRoles := fmt.Sprintf("%s %s", user.Roles, model.SYSTEM_POST_ALL_ROLE_ID)
 			updated, res := client.UpdateUserRoles(fullBot.UserId, newRoles)
 			if res.Error != nil {


### PR DESCRIPTION
#### Summary

https://github.com/mattermost/mattermost-plugin-apps/pull/142 made it so the bot is given a role to be able to post in any channel. This PR makes it so this role is only applied when the app specifically requests permission to do so.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-34920