### PR TITLE
[MM-35034] Clear ExpandedContext before passing it to the App

### DIFF
--- a/server/proxy/proxy.go
+++ b/server/proxy/proxy.go
@@ -40,6 +40,9 @@ func (p *Proxy) Call(sessionID, actingUserID string, creq *apps.CallRequest) *ap
 		return apps.NewProxyCallResponse(apps.NewErrorCallResponse(err), metadata)
 	}
 
+	// Clear any ExpandedContext as it should always be set by an expander for security reasons
+	creq.Context.ExpandedContext = apps.ExpandedContext{}
+
 	cc := p.conf.GetConfig().SetContextDefaultsForApp(creq.Context.AppID, creq.Context)
 
 	expander := p.newExpander(cc, p.mm, p.conf, p.store, sessionID)


### PR DESCRIPTION
#### Summary
Because we can't trust the client to not sent forged data, `ExpandedContext` needs to be cleared.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35034