### PR TITLE
[MM-35184] Pass app ID as positional argument to install command

### DIFF
--- a/e2e/cypress/integration/bindings/channel_header_spec.ts
+++ b/e2e/cypress/integration/bindings/channel_header_spec.ts
@@ -15,7 +15,7 @@ const pluginID = Cypress.config('pluginID');
 const helloManifestRoute = 'example/hello/mattermost-app.json';
 
 const addManifestCommand = `/apps debug-add-manifest --url ${baseURL}/plugins/${pluginID}/${helloManifestRoute}`;
-const installAppCommand = '/apps install --app-id http-hello --app-secret 1234';
+const installAppCommand = '/apps install http-hello --app-secret 1234';
 
 describe('Apps bindings - Channel header', () => {
     let testTeam;

--- a/server/command/install.go
+++ b/server/command/install.go
@@ -15,10 +15,8 @@ import (
 )
 
 func (s *service) executeInstall(params *params) (*model.CommandResponse, error) {
-	appID := ""
 	appSecret := ""
 	fs := pflag.NewFlagSet("", pflag.ContinueOnError)
-	fs.StringVar(&appID, "app-id", "", "ID of the app")
 	fs.StringVar(&appSecret, "app-secret", "", "App secret")
 	if err := fs.Parse(params.current); err != nil {
 		return errorOut(params, err)
@@ -28,9 +26,12 @@ func (s *service) executeInstall(params *params) (*model.CommandResponse, error)
 		return errorOut(params, utils.ErrForbidden)
 	}
 
-	if appID == "" {
-		return errorOut(params, errors.New("must select an App ID"))
+	if len(params.current) == 0 {
+		return errorOut(params, errors.New("you need to specify the app id"))
 	}
+
+	appID := params.current[0]
+
 	m, err := s.proxy.GetManifest(apps.AppID(appID))
 	if err != nil {
 		return errorOut(params, errors.Wrap(err, "manifest not found"))

--- a/server/command/main.go
+++ b/server/command/main.go
@@ -29,7 +29,7 @@ func (s *service) getSubCommands() map[string]commandHandler {
 	debugAddManifestAC.AddNamedTextArgument("url", "URL of the manifest to add", "URL", "", true)
 
 	installAC := model.NewAutocompleteData("install", "", "Install a registered app")
-	installAC.AddNamedTextArgument("app-id", "ID of the app to install", "appID", "", true)
+	installAC.AddTextArgument("ID of the app to install", "appID", "")
 	installAC.AddNamedTextArgument("app-secret", "Secret used to secure connection to App", "App Secret", "", false)
 
 	uninstallAC := model.NewAutocompleteData("uninstall", "", "Uninstall an app")


### PR DESCRIPTION
#### Summary
Instead of using the named argument `app-id` the app ID is passed as passed as a positional argument. This is consistent with the `/uninstall` command and shorter to use.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35184
