### PR TITLE
[MM-35089] Improve error and call logging

### DIFF
--- a/server/http/dialog/install.go
+++ b/server/http/dialog/install.go
@@ -144,6 +144,7 @@ func (d *dialog) handleInstall(w http.ResponseWriter, req *http.Request) {
 
 	app, out, err := d.proxy.InstallApp(sessionID, actingUserID, cc, noUserConsentForOAuth2, secret)
 	if err != nil {
+		d.mm.Log.Warn("Failed to install app", "app_id", cc.AppID, "error", err.Error())
 		respondWithError(w, http.StatusInternalServerError, err)
 		return
 	}

--- a/server/http/gateway/oauth2.go
+++ b/server/http/gateway/oauth2.go
@@ -17,6 +17,7 @@ func (g *gateway) remoteOAuth2Connect(w http.ResponseWriter, req *http.Request, 
 
 	connectURL, err := g.proxy.GetRemoteOAuth2ConnectURL(sessionID, actingUserID, appID)
 	if err != nil {
+		g.mm.Log.Warn("Failed to get remote OuAuth2 connect URL", "app_id", appID, "acting_user_id", actingUserID, "error", err.Error())
 		httputils.WriteError(w, err)
 		return
 	}
@@ -40,6 +41,7 @@ func (g *gateway) remoteOAuth2Complete(w http.ResponseWriter, req *http.Request,
 
 	err := g.proxy.CompleteRemoteOAuth2(sessionID, actingUserID, appID, urlValues)
 	if err != nil {
+		g.mm.Log.Warn("Failed to complete remote OuAuth2", "app_id", appID, "acting_user_id", actingUserID, "error", err.Error())
 		httputils.WriteError(w, err)
 		return
 	}

--- a/server/http/gateway/static.go
+++ b/server/http/gateway/static.go
@@ -29,6 +29,7 @@ func (g *gateway) static(w http.ResponseWriter, req *http.Request, _, _ string) 
 
 	body, status, err := g.proxy.GetAsset(appID, assetName)
 	if err != nil {
+		g.mm.Log.Debug("Failed to get asset", "app_id", appID, "asset_name", assetName, "error", err.Error())
 		httputils.WriteError(w, err)
 		return
 	}

--- a/server/http/restapi/call.go
+++ b/server/http/restapi/call.go
@@ -26,6 +26,7 @@ func (a *restapi) handleCall(w http.ResponseWriter, req *http.Request) {
 		"Received call response",
 		"app_id", call.Context.AppID,
 		"acting_user_id", call.Context.ActingUserID,
+		"error", res.ErrorText,
 		"type", res.Type,
 		"path", call.Path,
 	)

--- a/server/http/restapi/call.go
+++ b/server/http/restapi/call.go
@@ -22,5 +22,13 @@ func (a *restapi) handleCall(w http.ResponseWriter, req *http.Request) {
 		res.Type = apps.CallResponseTypeOK
 	}
 
+	a.mm.Log.Debug(
+		"Received call response",
+		"app_id", call.Context.AppID,
+		"acting_user_id", call.Context.ActingUserID,
+		"type", res.Type,
+		"path", res.Call.Path,
+	)
+
 	httputils.WriteJSON(w, res)
 }

--- a/server/http/restapi/call.go
+++ b/server/http/restapi/call.go
@@ -27,7 +27,7 @@ func (a *restapi) handleCall(w http.ResponseWriter, req *http.Request) {
 		"app_id", call.Context.AppID,
 		"acting_user_id", call.Context.ActingUserID,
 		"type", res.Type,
-		"path", res.Call.Path,
+		"path", call.Path,
 	)
 
 	httputils.WriteJSON(w, res)

--- a/server/logger/logger.go
+++ b/server/logger/logger.go
@@ -1,0 +1,41 @@
+package logger
+
+import (
+	apilogger "github.com/mattermost/mattermost-plugin-api/experimental/bot/logger"
+)
+
+type Logger = apilogger.Logger
+type LogContext = apilogger.LogContext
+
+type LogAPI interface {
+	Error(message string, keyValuePairs ...interface{})
+	Warn(message string, keyValuePairs ...interface{})
+	Info(message string, keyValuePairs ...interface{})
+	Debug(message string, keyValuePairs ...interface{})
+}
+
+type logWrapper struct {
+	api LogAPI
+}
+
+func (l *logWrapper) LogError(message string, keyValuePairs ...interface{}) {
+	l.api.Error(message, keyValuePairs)
+}
+
+func (l *logWrapper) LogWarn(message string, keyValuePairs ...interface{}) {
+	l.api.Warn(message, keyValuePairs)
+}
+
+func (l *logWrapper) LogInfo(message string, keyValuePairs ...interface{}) {
+	l.api.Info(message, keyValuePairs)
+}
+
+func (l *logWrapper) LogDebug(message string, keyValuePairs ...interface{}) {
+	l.api.Debug(message, keyValuePairs)
+}
+
+func New(api LogAPI) Logger {
+	lw := &logWrapper{api: api}
+
+	return apilogger.New(lw)
+}

--- a/server/proxy/bindings.go
+++ b/server/proxy/bindings.go
@@ -94,12 +94,13 @@ func (p *Proxy) GetBindingsForApp(sessionID, actingUserID string, cc *apps.Conte
 	}
 
 	resp := p.Call(sessionID, actingUserID, bindingsRequest)
-	if resp == nil || resp.Type != apps.CallResponseTypeOK {
-		if resp != nil && resp.Type == apps.CallResponseTypeError {
-			logger.Debugf("Error getting bindings. Error: " + resp.Error())
-		} else {
-			logger.Debugf("Bindings response is nil or unexpected type.")
-		}
+	if resp == nil || (resp.Type != apps.CallResponseTypeError && resp.Type != apps.CallResponseTypeOK) {
+		logger.Debugf("Bindings response is nil or unexpected type.")
+		return nil, nil
+	}
+
+	if resp.Type == apps.CallResponseTypeError {
+		logger.Debugf("Error getting bindings. Error: " + resp.Error())
 		return nil, nil
 	}
 

--- a/server/proxy/bindings.go
+++ b/server/proxy/bindings.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/mattermost/mattermost-plugin-apps/apps"
+	"github.com/mattermost/mattermost-plugin-apps/server/logger"
 	"github.com/mattermost/mattermost-plugin-apps/server/store"
 )
 
@@ -73,6 +74,10 @@ func (p *Proxy) GetBindingsForApp(sessionID, actingUserID string, cc *apps.Conte
 		return nil, nil
 	}
 
+	logger := logger.New(&p.mm.Log).With(logger.LogContext{
+		"app_id": cc.AppID,
+	})
+
 	appID := app.AppID
 	appCC := *cc
 	appCC.AppID = appID
@@ -87,11 +92,11 @@ func (p *Proxy) GetBindingsForApp(sessionID, actingUserID string, cc *apps.Conte
 
 	resp := p.Call(sessionID, actingUserID, bindingsRequest)
 	if resp == nil || resp.Type != apps.CallResponseTypeOK {
-		// TODO Log error (chance to flood the logs)
-		// p.mm.Log.Debug("Response is nil or unexpected type.")
-		// if resp != nil && resp.Type == apps.CallResponseTypeError {
-		// 	p.mm.Log.Debug("Error getting bindings. Error: " + resp.Error())
-		// }
+		if resp != nil && resp.Type == apps.CallResponseTypeError {
+			logger.Debugf("Error getting bindings. Error: " + resp.Error())
+		} else {
+			logger.Debugf("Bindings response is nil or unexpected type.")
+		}
 		return nil, nil
 	}
 
@@ -99,8 +104,7 @@ func (p *Proxy) GetBindingsForApp(sessionID, actingUserID string, cc *apps.Conte
 	b, _ := json.Marshal(resp.Data)
 	err := json.Unmarshal(b, &bindings)
 	if err != nil {
-		// TODO Log error (chance to flood the logs)
-		// p.mm.Log.Debug("Bindings are not of the right type.")
+		logger.Debugf("Bindings are not of the right type.")
 		return nil, nil
 	}
 


### PR DESCRIPTION
#### Summary
https://github.com/mattermost/mattermost-plugin-apps/commit/781dd61f2efa2bf48c5b206cfab226ca48a05d7a adds a `Debug` log message for any call originated from a client. I thought about also logging calls from the apps plugin, but it might be to spammy and the code to do that didn't turn out nice.


https://github.com/mattermost/mattermost-plugin-apps/commit/e6e5a13cb78d172a436a5dfc7d30629687214198 adds logging to certain interesting errors that previously only propagated to the client. I've made use of `github.com/mattermost/mattermost-plugin-api/experimental/bot/logger` by adding a small wrapper around it to make the API fit. Only the cases that are interesting for debugging and not spammy get logged. 

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-35089
Fixes https://mattermost.atlassian.net/browse/MM-34807
