### PR TITLE
include the expanded oauth2 user on oauth2complete

### DIFF
--- a/apps/manifest.go
+++ b/apps/manifest.go
@@ -127,6 +127,7 @@ var DefaultOnOAuth2Complete = &Call{
 		ActingUser:            ExpandSummary,
 		ActingUserAccessToken: ExpandAll,
 		OAuth2App:             ExpandAll,
+		OAuth2User:            ExpandAll,
 	},
 }
 


### PR DESCRIPTION
#### Summary
When the user completes oauth2, the call from the proxy plugin should send the expanded user access_token so the 3rd party app can immediately make calls.

#### Ticket Link
N/A