### PR TITLE
Add label for hello-webhooks command bindings

### DIFF
--- a/examples/go/hello-webhooks/bindings.json
+++ b/examples/go/hello-webhooks/bindings.json
@@ -6,7 +6,7 @@
 			"bindings": [
 				{
 					"icon": "http://localhost:8080/static/icon.png",
-                    "label": "hello-webhooks",
+					"label": "hello-webhooks",
 					"description": "Hello Webhooks App",
 					"hint": "[ send ]",
 					"bindings": [

--- a/examples/go/hello-webhooks/bindings.json
+++ b/examples/go/hello-webhooks/bindings.json
@@ -6,6 +6,7 @@
 			"bindings": [
 				{
 					"icon": "http://localhost:8080/static/icon.png",
+                    "label": "hello-webhooks",
 					"description": "Hello Webhooks App",
 					"hint": "[ send ]",
 					"bindings": [


### PR DESCRIPTION
#### Summary
This PR adds the label field for the hello-webhooks slash command.  Without the label, the `/hello-webhooks` slash command does not appear.


#### Ticket Link
n/a