### PR TITLE
Remove CancelButton and SubmitOnCancel form properties

### DIFF
--- a/apps/form.go
+++ b/apps/form.go
@@ -47,10 +47,6 @@ type Form struct {
 	// In Autocomplete, it is ignored.
 	SubmitButtons string `json:"submit_buttons,omitempty"`
 
-	// Adds a default "Cancel" button in the modal view
-	CancelButton  bool `json:"cancel_button,omitempty"`
-	SubmitOnCanel bool `json:"submit_on_cancel,omitempty"`
-
 	// Fields is the list of fields in the form.
 	Fields []*Field `json:"fields,omitempty"`
 }


### PR DESCRIPTION
#### Summary

`SubmitOnCancel` is currently not being used by the client, and we haven't designed how that fits within the call requests, so I've removed it from the data model.

`CancelButton` is not used, as we always show the cancel button in the apps modal.

Updates will need to be done in the typescript types when this is merged.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-30588