### PR TITLE
Change homepage url to point to docs

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
     "id": "com.mattermost.apps",
     "name": "Apps",
     "description": "This plugin powers the Mattermost Apps Framework and is required for any Apps to run",
-    "homepage_url": "https://github.com/mattermost/mattermost-plugin-apps",
+    "homepage_url": "https://mattermost.com/marketplace/app-framework",
     "support_url": "https://github.com/mattermost/mattermost-plugin-apps/issues",
     "release_notes_url": "https://github.com/mattermost/mattermost-plugin-apps/releases/tag/v0.6.0",
     "version": "0.6.0",

--- a/server/manifest.go
+++ b/server/manifest.go
@@ -15,7 +15,7 @@ const manifestStr = `
   "id": "com.mattermost.apps",
   "name": "Apps",
   "description": "This plugin powers the Mattermost Apps Framework and is required for any Apps to run",
-  "homepage_url": "https://github.com/mattermost/mattermost-plugin-apps",
+  "homepage_url": "https://mattermost.com/marketplace/app-framework",
   "support_url": "https://github.com/mattermost/mattermost-plugin-apps/issues",
   "release_notes_url": "https://github.com/mattermost/mattermost-plugin-apps/releases/tag/v0.6.0",
   "version": "0.6.0",


### PR DESCRIPTION
#### Summary

This PR changes the homepage url to point to https://mattermost.com/marketplace/app-framework

This is to match with the changes made in https://github.com/mattermost/mattermost-marketplace/pull/189#issuecomment-843396639