### PR TITLE
Allow installation from Apps running in AWS directly

### DIFF
--- a/cmd/appsctl/provision.go
+++ b/cmd/appsctl/provision.go
@@ -59,7 +59,7 @@ var provisionAppCmd = &cobra.Command{
 			len(out.LambdaARNs), len(out.StaticARNs))
 
 		fmt.Printf("You can now install it in Mattermost using:\n")
-		fmt.Printf("  /apps install --url %s\n\n", out.ManifestURL)
+		fmt.Printf("  /apps install aws %s %s\n\n", out.Manifest.AppID, out.Manifest.Version)
 
 		fmt.Printf("Execute role:\t%s\n", out.ExecuteRoleARN)
 		fmt.Printf("Execute policy:\t%s\n", out.ExecutePolicyARN)

--- a/e2e/cypress/integration/bindings/channel_header_spec.ts
+++ b/e2e/cypress/integration/bindings/channel_header_spec.ts
@@ -14,7 +14,7 @@ const baseURL = Cypress.config('baseUrl');
 const pluginID = Cypress.config('pluginID');
 const helloManifestRoute = 'example/hello/mattermost-app.json';
 
-const installAppCommand = `/apps install --url ${baseURL}/plugins/${pluginID}/${helloManifestRoute} --app-secret 1234`;
+const installAppCommand = `/apps install http ${baseURL}/plugins/${pluginID}/${helloManifestRoute} --app-secret 1234`;
 
 describe('Apps bindings - Channel header', () => {
     let testTeam;

--- a/server/mocks/mock_proxy/mock_proxy.go
+++ b/server/mocks/mock_proxy/mock_proxy.go
@@ -225,6 +225,21 @@ func (mr *MockServiceMockRecorder) GetManifest(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetManifest", reflect.TypeOf((*MockService)(nil).GetManifest), arg0)
 }
 
+// GetManifestFromS3 mocks base method.
+func (m *MockService) GetManifestFromS3(arg0 apps.AppID, arg1 apps.AppVersion) (*apps.Manifest, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetManifestFromS3", arg0, arg1)
+	ret0, _ := ret[0].(*apps.Manifest)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetManifestFromS3 indicates an expected call of GetManifestFromS3.
+func (mr *MockServiceMockRecorder) GetManifestFromS3(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetManifestFromS3", reflect.TypeOf((*MockService)(nil).GetManifestFromS3), arg0, arg1)
+}
+
 // GetRemoteOAuth2ConnectURL mocks base method.
 func (m *MockService) GetRemoteOAuth2ConnectURL(arg0, arg1 string, arg2 apps.AppID) (string, error) {
 	m.ctrl.T.Helper()

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -94,12 +94,12 @@ func (p *Plugin) OnActivate() error {
 	p.httpOut = httpout.NewService(p.conf)
 	p.mm.Log.Debug("Initialized outgoing HTTP")
 
-	p.store = store.NewService(p.mm, p.conf)
+	p.store = store.NewService(p.mm, p.conf, p.aws, conf.AWSS3Bucket)
 	// manifest store
 	mstore := p.store.Manifest
 	mstore.Configure(conf)
 	if conf.MattermostCloudMode {
-		err = mstore.InitGlobal(p.aws, conf.AWSS3Bucket, p.httpOut)
+		err = mstore.InitGlobal(p.httpOut)
 		if err != nil {
 			return errors.Wrap(err, "failed to initialize the global manifest list from marketplace")
 		}

--- a/server/proxy/bindings_test.go
+++ b/server/proxy/bindings_test.go
@@ -596,7 +596,7 @@ func newTestProxyForBindings(testData []bindingTestData, ctrl *gomock.Controller
 		},
 	})
 
-	s := store.NewService(mm, conf)
+	s := store.NewService(mm, conf, nil, "")
 	appStore := mock_store.NewMockAppStore(ctrl)
 	s.App = appStore
 

--- a/server/proxy/install.go
+++ b/server/proxy/install.go
@@ -86,17 +86,26 @@ func (p *Proxy) InstallApp(sessionID, actingUserID string, cc *apps.Context, tru
 		return nil, "", err
 	}
 
-	creq := &apps.CallRequest{
-		Call:    *apps.DefaultOnInstall.WithOverrides(app.OnInstall),
-		Context: cc,
+	var message md.MD
+	if app.OnInstall != nil {
+		creq := &apps.CallRequest{
+			Call:    *apps.DefaultOnInstall.WithOverrides(app.OnInstall),
+			Context: cc,
+		}
+		resp := p.Call(sessionID, actingUserID, creq)
+		if resp.Type == apps.CallResponseTypeError {
+			p.mm.Log.Warn("OnInstall failed, installing app anyway", "err", resp.Error(), "app_id", app.AppID)
+		}
+
+		message = resp.Markdown
 	}
-	resp := p.Call(sessionID, actingUserID, creq)
-	if resp.Type == apps.CallResponseTypeError {
-		return nil, "", errors.Wrap(resp, "install failed")
+
+	if message == "" {
+		message = md.MD(fmt.Sprintf("Successfully install %s", app.AppID))
 	}
 
 	p.dispatchRefreshBindingsEvent(cc.ActingUserID)
-	return app, resp.Markdown, nil
+	return app, message, nil
 }
 
 func (p *Proxy) ensureOAuthApp(app *apps.App, noUserConsent bool, actingUserID string, asAdmin *model.Client4) (*model.OAuthApp, error) {

--- a/server/proxy/list.go
+++ b/server/proxy/list.go
@@ -16,6 +16,10 @@ func (p *Proxy) GetManifest(appID apps.AppID) (*apps.Manifest, error) {
 	return p.store.Manifest.Get(appID)
 }
 
+func (p *Proxy) GetManifestFromS3(appID apps.AppID, version apps.AppVersion) (*apps.Manifest, error) {
+	return p.store.Manifest.GetFromS3(appID, version)
+}
+
 func (p *Proxy) GetInstalledApp(appID apps.AppID) (*apps.App, error) {
 	return p.store.App.Get(appID)
 }

--- a/server/proxy/proxy_test.go
+++ b/server/proxy/proxy_test.go
@@ -63,7 +63,7 @@ func newTestProxy(testApps []*apps.App, ctrl *gomock.Controller) *Proxy {
 		},
 	})
 
-	s := store.NewService(mm, conf)
+	s := store.NewService(mm, conf, nil, "")
 	appStore := mock_store.NewMockAppStore(ctrl)
 	s.App = appStore
 

--- a/server/proxy/service.go
+++ b/server/proxy/service.go
@@ -50,6 +50,7 @@ type Service interface {
 	GetInstalledApps() []*apps.App
 	GetListedApps(filter string) []*apps.ListedApp
 	GetManifest(appID apps.AppID) (*apps.Manifest, error)
+	GetManifestFromS3(appID apps.AppID, version apps.AppVersion) (*apps.Manifest, error)
 	InstallApp(sessionID, actingUserID string, cc *apps.Context, trusted bool, secret string) (*apps.App, md.MD, error)
 	SynchronizeInstalledApps() error
 	UninstallApp(sessionID, actingUserID string, appID apps.AppID) error

--- a/server/store/service.go
+++ b/server/store/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mattermost/mattermost-server/v5/model"
 
 	"github.com/mattermost/mattermost-plugin-apps/server/config"
+	"github.com/mattermost/mattermost-plugin-apps/upstream/upaws"
 )
 
 type Service struct {
@@ -25,12 +26,17 @@ type Service struct {
 
 	mm   *pluginapi.Client
 	conf config.Service
+
+	aws           upaws.Client
+	s3AssetBucket string
 }
 
-func NewService(mm *pluginapi.Client, conf config.Service) *Service {
+func NewService(mm *pluginapi.Client, conf config.Service, aws upaws.Client, s3AssetBucket string) *Service {
 	s := &Service{
-		mm:   mm,
-		conf: conf,
+		mm:            mm,
+		conf:          conf,
+		aws:           aws,
+		s3AssetBucket: s3AssetBucket,
 	}
 	s.App = &appStore{
 		Service: s,

--- a/server/store/service_test.go
+++ b/server/store/service_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestHashkey(t *testing.T) {
-	s := NewService(nil, nil)
+	s := NewService(nil, nil, nil, "")
 	for _, tc := range []struct {
 		name                                string
 		globalPrefix, botUserID, prefix, id string

--- a/server/store/subscriptions_test.go
+++ b/server/store/subscriptions_test.go
@@ -25,7 +25,7 @@ func TestDeleteSub(t *testing.T) {
 
 	apiClient := pluginapi.NewClient(mockAPI)
 	conf := config.NewService(apiClient, config.BuildConfig{}, botID)
-	s := NewService(apiClient, conf)
+	s := NewService(apiClient, conf, nil, "")
 
 	toDelete := apps.Subscription{
 		Subject:   "user_joined_channel",
@@ -132,7 +132,7 @@ func TestGetSubs(t *testing.T) {
 
 	apiClient := pluginapi.NewClient(mockAPI)
 	conf := config.NewService(apiClient, config.BuildConfig{}, botID)
-	s := NewService(apiClient, conf)
+	s := NewService(apiClient, conf, nil, "")
 
 	emptySubs := []*apps.Subscription{}
 	emptySubsBytes, _ := json.Marshal(emptySubs)
@@ -195,7 +195,7 @@ func TestStoreSub(t *testing.T) {
 
 	apiClient := pluginapi.NewClient(mockAPI)
 	conf := config.NewService(apiClient, config.BuildConfig{}, botID)
-	s := NewService(apiClient, conf)
+	s := NewService(apiClient, conf, nil, "")
 
 	toStore := apps.Subscription{
 		Subject:   "user_joined_channel",

--- a/upstream/upaws/provision_app.go
+++ b/upstream/upaws/provision_app.go
@@ -149,7 +149,7 @@ func provisionS3Manifest(c Client, log Logger, pd *ProvisionData, params Provisi
 	buffer := bytes.NewBuffer(data)
 
 	// Make the manifest publicly visible.
-	url, err := c.UploadS3(params.Bucket, pd.ManifestKey, buffer, true)
+	url, err := c.UploadS3(params.Bucket, pd.ManifestKey, buffer, false)
 	if err != nil {
 		return errors.Wrapf(err, "can't upload manifest file for the app - %s", pd.Manifest.AppID)
 	}


### PR DESCRIPTION
#### Summary
Instead of install an AWS app via a public readable manifest, there is now a slash command for that. The other commands have been reorganized accordingly:
- `/apps install marketplace com.mattermost.servicenow` is used in Cloud to install from the Marketplace
- `/apps install http http://localhost:3000/manifest --app-secret abc` is used in on-prem to install from an HTTP server
- `/apps install aws com.mattermost.servicenow 0.1.0` is used in on-prem to install an App that was previously deployed to cloud

The PR is based on https://github.com/mattermost/mattermost-plugin-apps/pull/193 to minimize merge conflicts.

#### Ticket Link
None