### PR TITLE
[MM-30595] Add support for relative icon path to bindings and forms

### DIFF
--- a/apps/binding.go
+++ b/apps/binding.go
@@ -65,7 +65,7 @@ package apps
 //              "bindings": [
 //                  {
 //                      "location": "send-button",
-//                      "icon": "http://localhost:8080/static/icon.png",
+//                      "icon": "icon.png",
 //                      "label":"send hello message",
 //                      "call": {
 //                          "path": "/send-modal"
@@ -77,7 +77,7 @@ package apps
 //              "location": "/command",
 //              "bindings": [
 //                  {
-//                      "icon": "http://localhost:8080/static/icon.png",
+//                      "icon": "icon.png",
 //                      "description": "Hello World app",
 //                      "hint":        "[send]",
 //                      "bindings": [

--- a/examples/go/hello-oauth2/bindings.json
+++ b/examples/go/hello-oauth2/bindings.json
@@ -5,7 +5,7 @@
 			"location": "/command",
 			"bindings": [
 				{
-					"icon": "http://localhost:8080/static/icon.png",
+					"icon": "icon.png",
 					"label": "hello-oauth2",
 					"description": "Hello remote (3rd party) OAuth2 App",
 					"hint": "[configure | connect | send]",

--- a/examples/go/hello-oauth2/configure_form.json
+++ b/examples/go/hello-oauth2/configure_form.json
@@ -2,7 +2,7 @@
 	"type": "form",
 	"form": {
 		"title": "Configures Google OAuth2 App credentials",
-		"icon": "http://localhost:8080/static/icon.png",
+		"icon": "icon.png",
 		"fields": [
 			{
 				"type": "text",

--- a/examples/go/hello-oauth2/connect_form.json
+++ b/examples/go/hello-oauth2/connect_form.json
@@ -2,7 +2,7 @@
 	"type": "form",
 	"form": {
 		"title": "Connect to Google",
-		"icon": "http://localhost:8080/static/icon.png",
+		"icon": "icon.png",
 		"call": {
 			"path": "/connect",
 			"expand": {

--- a/examples/go/hello-oauth2/send_form.json
+++ b/examples/go/hello-oauth2/send_form.json
@@ -2,7 +2,7 @@
 	"type": "form",
 	"form": {
 		"title": "Send a Google-connected 'hello, world!' message",
-		"icon": "http://localhost:8080/static/icon.png",
+		"icon": "icon.png",
 		"call": {
 			"path": "/send",
 			"expand": {

--- a/examples/go/hello-webhooks/bindings.json
+++ b/examples/go/hello-webhooks/bindings.json
@@ -5,7 +5,7 @@
 			"location": "/command",
 			"bindings": [
 				{
-					"icon": "http://localhost:8080/static/icon.png",
+					"icon": "icon.png",
 					"description": "Hello Webhooks App",
 					"hint": "[ send ]",
 					"bindings": [

--- a/examples/go/hello-webhooks/info_form.json
+++ b/examples/go/hello-webhooks/info_form.json
@@ -2,7 +2,7 @@
 	"type": "form",
 	"form": {
 		"title": "Display the webhook URL",
-		"icon": "http://localhost:8080/static/icon.png",
+		"icon": "icon.png",
 		"call": {
 			"path": "/info",
 			"expand": {

--- a/examples/go/hello-webhooks/send_form.json
+++ b/examples/go/hello-webhooks/send_form.json
@@ -2,7 +2,7 @@
 	"type": "form",
 	"form": {
 		"title": "Send a test webhook message",
-		"icon": "http://localhost:8080/static/icon.png",
+		"icon": "icon.png",
 		"call": {
 			"path": "/send"
 		},

--- a/examples/go/hello-world/bindings.json
+++ b/examples/go/hello-world/bindings.json
@@ -6,7 +6,7 @@
 			"bindings": [
 				{
 					"location": "send-button",
-					"icon": "http://localhost:8080/static/icon.png",
+					"icon": "icon.png",
 					"label":"send hello message",
 					"call": {
 						"path": "/send-modal"
@@ -18,7 +18,7 @@
 			"location": "/command",
 			"bindings": [
 				{
-					"icon": "http://localhost:8080/static/icon.png",
+					"icon": "icon.png",
 					"label": "helloworld",
 					"description": "Hello World app",
 					"hint": "[send]",

--- a/examples/go/hello-world/send_form.json
+++ b/examples/go/hello-world/send_form.json
@@ -2,7 +2,7 @@
 	"type": "form",
 	"form": {
 		"title": "Hello, world!",
-		"icon": "http://localhost:8080/static/icon.png",
+		"icon": "icon.png",
 		"fields": [
 			{
 				"type": "text",

--- a/examples/js/hello-world/app.js
+++ b/examples/js/hello-world/app.js
@@ -33,7 +33,7 @@ app.post('/bindings', (req, res) => {
                 bindings: [
                     {
                         location: 'send-button',
-                        icon: 'http://localhost:8080/static/icon.png',
+                        icon: 'icon.png',
                         label: 'send hello message',
                         call: {
                             path: '/send-modal',
@@ -45,7 +45,7 @@ app.post('/bindings', (req, res) => {
                 location: '/command',
                 bindings: [
                     {
-                        icon: 'http://localhost:8080/static/icon.png',
+                        icon: 'icon.png',
                         label: 'helloworld',
                         description: 'Hello World app',
                         hint: '[send]',
@@ -70,7 +70,7 @@ app.post(['/send/form', '/send-modal/submit'], (req, res) => {
         type: 'form',
         form: {
             title: 'Hello, world!',
-            icon: 'http://localhost:8080/static/icon.png',
+            icon: 'icon.png',
             fields: [
                 {
                     type: 'text',

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -57,25 +57,29 @@ type Config struct {
 	MaxWebhookSize int64
 }
 
-func (c Config) SetContextDefaults(cc *apps.Context) *apps.Context {
+func (conf Config) SetContextDefaults(cc *apps.Context) *apps.Context {
 	if cc == nil {
 		cc = &apps.Context{}
 	}
-	cc.BotUserID = c.BotUserID
-	cc.MattermostSiteURL = c.MattermostSiteURL
+	cc.BotUserID = conf.BotUserID
+	cc.MattermostSiteURL = conf.MattermostSiteURL
 	return cc
 }
 
-func (c Config) SetContextDefaultsForApp(appID apps.AppID, cc *apps.Context) *apps.Context {
+func (conf Config) SetContextDefaultsForApp(appID apps.AppID, cc *apps.Context) *apps.Context {
 	if cc == nil {
 		cc = &apps.Context{}
 	}
-	cc = c.SetContextDefaults(cc)
+	cc = conf.SetContextDefaults(cc)
 	cc.AppID = appID
-	cc.AppPath = path.Join(c.PluginURLPath, PathApps, string(appID))
+	cc.AppPath = path.Join(conf.PluginURLPath, PathApps, string(appID))
 	return cc
 }
 
-func (c Config) AppPath(appID apps.AppID) string {
-	return c.PluginURL + PathApps + "/" + string(appID)
+func (conf Config) AppURL(appID apps.AppID) string {
+	return conf.PluginURL + path.Join(PathApps, string(appID))
+}
+
+func (conf Config) StaticURL(appID apps.AppID, name string) string {
+	return conf.AppURL(appID) + "/" + path.Join(apps.StaticFolder, name)
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -80,6 +80,7 @@ func (conf Config) AppURL(appID apps.AppID) string {
 	return conf.PluginURL + path.Join(PathApps, string(appID))
 }
 
+// StaticURL returns the URL to a static asset.
 func (conf Config) StaticURL(appID apps.AppID, name string) string {
 	return conf.AppURL(appID) + "/" + path.Join(apps.StaticFolder, name)
 }

--- a/server/httpin/gateway/static.go
+++ b/server/httpin/gateway/static.go
@@ -3,9 +3,6 @@ package gateway
 import (
 	"io"
 	"net/http"
-	"net/url"
-	"path"
-	"strings"
 
 	"github.com/gorilla/mux"
 
@@ -25,7 +22,7 @@ func (g *gateway) static(w http.ResponseWriter, req *http.Request, _, _ string) 
 		httputils.WriteError(w, utils.NewInvalidError("invalid URL format"))
 		return
 	}
-	assetName, err := cleanStaticPath(vars["name"])
+	assetName, err := utils.CleanStaticPath(vars["name"])
 	if err != nil {
 		httputils.WriteError(w, err)
 		return
@@ -55,28 +52,4 @@ func (g *gateway) static(w http.ResponseWriter, req *http.Request, _, _ string) 
 func copyHeader(dst, src http.Header) {
 	headerKey := "Content-Type"
 	dst.Add(headerKey, src.Get(headerKey))
-}
-
-func cleanStaticPath(got string) (unescaped string, err error) {
-	if got == "" {
-		return "", utils.NewInvalidError("asset name is not specified")
-	}
-	for escaped := got; ; escaped = unescaped {
-		unescaped, err = url.PathUnescape(escaped)
-		if err != nil {
-			return "", err
-		}
-		if unescaped == escaped {
-			break
-		}
-	}
-	if unescaped[0] == '/' {
-		return "", utils.NewInvalidError("asset names may not start with a '/'")
-	}
-
-	assetName := path.Clean(unescaped)
-	if assetName == "." || strings.HasPrefix(assetName, "../") {
-		return "", utils.NewInvalidError("bad path: %s", got)
-	}
-	return assetName, nil
 }

--- a/server/proxy/bindings.go
+++ b/server/proxy/bindings.go
@@ -113,6 +113,7 @@ func (p *Proxy) scanAppBindings(app *apps.App, bindings []*apps.Binding, locPref
 	out := []*apps.Binding{}
 	locationsUsed := map[apps.Location]bool{}
 	labelsUsed := map[string]bool{}
+	conf := p.conf.GetConfig()
 
 	for _, appB := range bindings {
 		// clone just in case
@@ -150,6 +151,16 @@ func (p *Proxy) scanAppBindings(app *apps.App, bindings []*apps.Binding, locPref
 			locationsUsed[appB.Location] = true
 			labelsUsed[appB.Label] = true
 			b.AppID = app.Manifest.AppID
+		}
+
+		if b.Icon != "" {
+			icon, err := convertToStaticPath(conf, app.AppID, b.Icon)
+			if err != nil {
+				p.mm.Log.Debug("Invalid icon path in binding", "app_id", app.AppID, "icon", b.Icon, "error", err.Error())
+				b.Icon = ""
+			} else {
+				b.Icon = icon
+			}
 		}
 
 		if len(b.Bindings) != 0 {

--- a/server/proxy/bindings.go
+++ b/server/proxy/bindings.go
@@ -154,7 +154,7 @@ func (p *Proxy) scanAppBindings(app *apps.App, bindings []*apps.Binding, locPref
 		}
 
 		if b.Icon != "" {
-			icon, err := convertToStaticPath(conf, app.AppID, b.Icon)
+			icon, err := normalizeStaticPath(conf, app.AppID, b.Icon)
 			if err != nil {
 				p.mm.Log.Debug("Invalid icon path in binding", "app_id", app.AppID, "icon", b.Icon, "error", err.Error())
 				b.Icon = ""

--- a/server/proxy/bindings_test.go
+++ b/server/proxy/bindings_test.go
@@ -329,7 +329,7 @@ func TestGetBindingsCommands(t *testing.T) {
 								{
 									Location:    "message",
 									Label:       "message",
-									Icon:        "message command icon",
+									Icon:        "https://example.com/image.png",
 									Hint:        "message command hint",
 									Description: "message command description",
 								}, {
@@ -341,7 +341,7 @@ func TestGetBindingsCommands(t *testing.T) {
 								}, {
 									Location:    "manage",
 									Label:       "manage",
-									Icon:        "manage command icon",
+									Icon:        "../some/invalid/path",
 									Hint:        "manage command hint",
 									Description: "manage command description",
 									Bindings: []*apps.Binding{
@@ -421,7 +421,7 @@ func TestGetBindingsCommands(t *testing.T) {
 							AppID:       apps.AppID("app1"),
 							Location:    "message",
 							Label:       "message",
-							Icon:        "https://test.mattermost.com/plugins/com.mattermost.apps/apps/app1/static/message command icon",
+							Icon:        "https://example.com/image.png",
 							Hint:        "message command hint",
 							Description: "message command description",
 						}, {
@@ -435,7 +435,7 @@ func TestGetBindingsCommands(t *testing.T) {
 							AppID:       apps.AppID("app1"),
 							Location:    "manage",
 							Label:       "manage",
-							Icon:        "https://test.mattermost.com/plugins/com.mattermost.apps/apps/app1/static/manage command icon",
+							Icon:        "",
 							Hint:        "manage command hint",
 							Description: "manage command description",
 							Bindings: []*apps.Binding{
@@ -587,7 +587,12 @@ func TestDuplicateCommand(t *testing.T) {
 
 func newTestProxyForBindings(testData []bindingTestData, ctrl *gomock.Controller) *Proxy {
 	testAPI := &plugintest.API{}
-	testAPI.On("LogDebug", mock.Anything).Return(nil)
+	testAPI.On("LogDebug", mock.AnythingOfType("string")).Return(nil)
+	testAPI.On("LogDebug", mock.AnythingOfType("string"),
+		mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything,
+	).Return(nil)
 	mm := pluginapi.NewClient(testAPI)
 
 	conf := config.Config{

--- a/server/proxy/bindings_test.go
+++ b/server/proxy/bindings_test.go
@@ -413,7 +413,7 @@ func TestGetBindingsCommands(t *testing.T) {
 					AppID:       apps.AppID("app1"),
 					Location:    "base command location",
 					Label:       "base command label",
-					Icon:        "base command icon",
+					Icon:        "https://test.mattermost.com/plugins/com.mattermost.apps/apps/app1/static/base command icon",
 					Hint:        "base command hint",
 					Description: "base command description",
 					Bindings: []*apps.Binding{
@@ -421,21 +421,21 @@ func TestGetBindingsCommands(t *testing.T) {
 							AppID:       apps.AppID("app1"),
 							Location:    "message",
 							Label:       "message",
-							Icon:        "message command icon",
+							Icon:        "https://test.mattermost.com/plugins/com.mattermost.apps/apps/app1/static/message command icon",
 							Hint:        "message command hint",
 							Description: "message command description",
 						}, {
 							AppID:       apps.AppID("app1"),
 							Location:    "message-modal",
 							Label:       "message-modal",
-							Icon:        "message-modal command icon",
+							Icon:        "https://test.mattermost.com/plugins/com.mattermost.apps/apps/app1/static/message-modal command icon",
 							Hint:        "message-modal command hint",
 							Description: "message-modal command description",
 						}, {
 							AppID:       apps.AppID("app1"),
 							Location:    "manage",
 							Label:       "manage",
-							Icon:        "manage command icon",
+							Icon:        "https://test.mattermost.com/plugins/com.mattermost.apps/apps/app1/static/manage command icon",
 							Hint:        "manage command hint",
 							Description: "manage command description",
 							Bindings: []*apps.Binding{
@@ -443,14 +443,14 @@ func TestGetBindingsCommands(t *testing.T) {
 									AppID:       apps.AppID("app1"),
 									Location:    "subscribe",
 									Label:       "subscribe",
-									Icon:        "subscribe command icon",
+									Icon:        "https://test.mattermost.com/plugins/com.mattermost.apps/apps/app1/static/subscribe command icon",
 									Hint:        "subscribe command hint",
 									Description: "subscribe command description",
 								}, {
 									AppID:       apps.AppID("app1"),
 									Location:    "unsubscribe",
 									Label:       "unsubscribe",
-									Icon:        "unsubscribe command icon",
+									Icon:        "https://test.mattermost.com/plugins/com.mattermost.apps/apps/app1/static/unsubscribe command icon",
 									Hint:        "unsubscribe command hint",
 									Description: "unsubscribe command description",
 								},
@@ -462,7 +462,7 @@ func TestGetBindingsCommands(t *testing.T) {
 					AppID:       apps.AppID("app2"),
 					Location:    "app2 base command location",
 					Label:       "app2 base command label",
-					Icon:        "app2 base command icon",
+					Icon:        "https://test.mattermost.com/plugins/com.mattermost.apps/apps/app2/static/app2 base command icon",
 					Hint:        "app2 base command hint",
 					Description: "app2 base command description",
 					Bindings: []*apps.Binding{
@@ -470,7 +470,7 @@ func TestGetBindingsCommands(t *testing.T) {
 							AppID:       apps.AppID("app2"),
 							Location:    "connect",
 							Label:       "connect",
-							Icon:        "connect command icon",
+							Icon:        "https://test.mattermost.com/plugins/com.mattermost.apps/apps/app2/static/connect command icon",
 							Hint:        "connect command hint",
 							Description: "connect command description",
 						},
@@ -558,7 +558,7 @@ func TestDuplicateCommand(t *testing.T) {
 					AppID:       apps.AppID("app1"),
 					Location:    "base command location",
 					Label:       "base command label",
-					Icon:        "base command icon",
+					Icon:        "https://test.mattermost.com/plugins/com.mattermost.apps/apps/app1/static/base command icon",
 					Hint:        "base command hint",
 					Description: "base command description",
 					Bindings: []*apps.Binding{
@@ -566,7 +566,7 @@ func TestDuplicateCommand(t *testing.T) {
 							AppID:    apps.AppID("app1"),
 							Location: "sub1",
 							Label:    "sub1",
-							Icon:     "sub1 icon 1",
+							Icon:     "https://test.mattermost.com/plugins/com.mattermost.apps/apps/app1/static/sub1 icon 1",
 						},
 					},
 				},
@@ -590,13 +590,16 @@ func newTestProxyForBindings(testData []bindingTestData, ctrl *gomock.Controller
 	testAPI.On("LogDebug", mock.Anything).Return(nil)
 	mm := pluginapi.NewClient(testAPI)
 
-	conf := config.NewTestConfigurator(config.Config{}).WithMattermostConfig(model.Config{
+	conf := config.Config{
+		PluginURL: "https://test.mattermost.com/plugins/com.mattermost.apps",
+	}
+	confService := config.NewTestConfigurator(conf).WithMattermostConfig(model.Config{
 		ServiceSettings: model.ServiceSettings{
-			SiteURL: model.NewString("test.mattermost.com"),
+			SiteURL: model.NewString("https://test.mattermost.com"),
 		},
 	})
 
-	s := store.NewService(mm, conf)
+	s := store.NewService(mm, confService)
 	appStore := mock_store.NewMockAppStore(ctrl)
 	s.App = appStore
 
@@ -625,7 +628,7 @@ func newTestProxyForBindings(testData []bindingTestData, ctrl *gomock.Controller
 		mm:               mm,
 		store:            s,
 		builtinUpstreams: upstreams,
-		conf:             conf,
+		conf:             confService,
 	}
 
 	return p

--- a/server/proxy/expand.go
+++ b/server/proxy/expand.go
@@ -146,8 +146,8 @@ func (e *expander) ExpandForApp(app *apps.App, expand *apps.Expand) (*apps.Conte
 		if expand.OAuth2App != "" {
 			clone.ExpandedContext.OAuth2.ClientID = app.RemoteOAuth2.ClientID
 			clone.ExpandedContext.OAuth2.ClientSecret = app.RemoteOAuth2.ClientSecret
-			clone.ExpandedContext.OAuth2.ConnectURL = conf.AppPath(app.AppID) + config.PathRemoteOAuth2Connect
-			clone.ExpandedContext.OAuth2.CompleteURL = conf.AppPath(app.AppID) + config.PathRemoteOAuth2Complete
+			clone.ExpandedContext.OAuth2.ConnectURL = conf.AppURL(app.AppID) + config.PathRemoteOAuth2Connect
+			clone.ExpandedContext.OAuth2.CompleteURL = conf.AppURL(app.AppID) + config.PathRemoteOAuth2Complete
 		}
 
 		if expand.OAuth2User != "" && e.OAuth2.User == nil && e.ActingUserID != "" {

--- a/server/proxy/install.go
+++ b/server/proxy/install.go
@@ -106,7 +106,7 @@ func (p *Proxy) ensureOAuthApp(app *apps.App, noUserConsent bool, actingUserID s
 		}
 	}
 
-	oauth2CallbackURL := p.conf.GetConfig().AppPath(app.AppID) + config.PathMattermostOAuth2Complete
+	oauth2CallbackURL := p.conf.GetConfig().AppURL(app.AppID) + config.PathMattermostOAuth2Complete
 
 	// For the POC this should work, but for the final product I would opt for a RPC method to register the App
 	oauthApp, response := asAdmin.CreateOAuthApp(&model.OAuthApp{

--- a/server/proxy/proxy.go
+++ b/server/proxy/proxy.go
@@ -8,10 +8,12 @@ import (
 	"io"
 	"net/http"
 	"path"
+	"strings"
 
 	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost-plugin-apps/apps"
+	"github.com/mattermost/mattermost-plugin-apps/server/config"
 	"github.com/mattermost/mattermost-plugin-apps/server/upstream"
 	"github.com/mattermost/mattermost-plugin-apps/server/upstream/upawslambda"
 	"github.com/mattermost/mattermost-plugin-apps/server/upstream/uphttp"
@@ -50,7 +52,8 @@ func (p *Proxy) Call(sessionID, actingUserID string, creq *apps.CallRequest) *ap
 	// Clear any ExpandedContext as it should always be set by an expander for security reasons
 	creq.Context.ExpandedContext = apps.ExpandedContext{}
 
-	cc := p.conf.GetConfig().SetContextDefaultsForApp(creq.Context.AppID, creq.Context)
+	conf := p.conf.GetConfig()
+	cc := conf.SetContextDefaultsForApp(creq.Context.AppID, creq.Context)
 
 	expander := p.newExpander(cc, p.mm, p.conf, p.store, sessionID)
 	cc, err = expander.ExpandForApp(app, creq.Expand)
@@ -61,11 +64,38 @@ func (p *Proxy) Call(sessionID, actingUserID string, creq *apps.CallRequest) *ap
 	clone.Context = cc
 
 	callResponse := upstream.Call(up, &clone)
+
 	if callResponse.Type == "" {
 		callResponse.Type = apps.CallResponseTypeOK
 	}
 
+	if callResponse.Form != nil && callResponse.Form.Icon != "" {
+		icon, err := convertToStaticPath(conf, cc.AppID, callResponse.Form.Icon)
+		if err != nil {
+			p.mm.Log.Debug("Invalid icon path in form. Ignoring it.", "app_id", app.AppID, "icon", callResponse.Form.Icon, "error", err.Error())
+			callResponse.Form.Icon = ""
+		} else {
+			callResponse.Form.Icon = icon
+		}
+	}
+
 	return apps.NewProxyCallResponse(callResponse, metadata)
+}
+
+// convertToStaticPath converts a given URL to a absolute one pointing to a static asset if needed.
+// If icon is an absolute URL, it's not changed.
+// Otherwise assume it's a path to a static asset and the static path URL prepended.
+func convertToStaticPath(conf config.Config, appID apps.AppID, icon string) (string, error) {
+	if !strings.HasPrefix(icon, "http://") && !strings.HasPrefix(icon, "https://") {
+		cleanIcon, err := utils.CleanStaticPath(icon)
+		if err != nil {
+			return "", errors.Wrap(err, "invalid icon path")
+		}
+
+		icon = conf.StaticURL(appID, cleanIcon)
+	}
+
+	return icon, nil
 }
 
 func (p *Proxy) Notify(cc *apps.Context, subj apps.Subject) error {

--- a/server/proxy/proxy.go
+++ b/server/proxy/proxy.go
@@ -70,7 +70,7 @@ func (p *Proxy) Call(sessionID, actingUserID string, creq *apps.CallRequest) *ap
 	}
 
 	if callResponse.Form != nil && callResponse.Form.Icon != "" {
-		icon, err := convertToStaticPath(conf, cc.AppID, callResponse.Form.Icon)
+		icon, err := normalizeStaticPath(conf, cc.AppID, callResponse.Form.Icon)
 		if err != nil {
 			p.mm.Log.Debug("Invalid icon path in form. Ignoring it.", "app_id", app.AppID, "icon", callResponse.Form.Icon, "error", err.Error())
 			callResponse.Form.Icon = ""
@@ -82,10 +82,10 @@ func (p *Proxy) Call(sessionID, actingUserID string, creq *apps.CallRequest) *ap
 	return apps.NewProxyCallResponse(callResponse, metadata)
 }
 
-// convertToStaticPath converts a given URL to a absolute one pointing to a static asset if needed.
+// normalizeStaticPath converts a given URL to a absolute one pointing to a static asset if needed.
 // If icon is an absolute URL, it's not changed.
 // Otherwise assume it's a path to a static asset and the static path URL prepended.
-func convertToStaticPath(conf config.Config, appID apps.AppID, icon string) (string, error) {
+func normalizeStaticPath(conf config.Config, appID apps.AppID, icon string) (string, error) {
 	if !strings.HasPrefix(icon, "http://") && !strings.HasPrefix(icon, "https://") {
 		cleanIcon, err := utils.CleanStaticPath(icon)
 		if err != nil {

--- a/server/utils/path.go
+++ b/server/utils/path.go
@@ -1,0 +1,31 @@
+package utils
+
+import (
+	"net/url"
+	"path"
+	"strings"
+)
+
+func CleanStaticPath(got string) (unescaped string, err error) {
+	if got == "" {
+		return "", NewInvalidError("asset name is not specified")
+	}
+	for escaped := got; ; escaped = unescaped {
+		unescaped, err = url.PathUnescape(escaped)
+		if err != nil {
+			return "", err
+		}
+		if unescaped == escaped {
+			break
+		}
+	}
+	if unescaped[0] == '/' {
+		return "", NewInvalidError("asset names may not start with a '/'")
+	}
+
+	assetName := path.Clean(unescaped)
+	if assetName == "." || strings.HasPrefix(assetName, "../") {
+		return "", NewInvalidError("bad path: %s", got)
+	}
+	return assetName, nil
+}

--- a/server/utils/path_test.go
+++ b/server/utils/path_test.go
@@ -1,4 +1,4 @@
-package gateway
+package utils
 
 import (
 	"testing"
@@ -39,7 +39,7 @@ func TestCleanStaticPath(t *testing.T) {
 		},
 	} {
 		t.Run(tc.p, func(t *testing.T) {
-			c, err := cleanStaticPath(tc.p)
+			c, err := CleanStaticPath(tc.p)
 			if tc.expectedError != "" {
 				require.NotNil(t, err)
 				require.Equal(t, tc.expectedError, err.Error())


### PR DESCRIPTION
#### Summary
With this PR apps can define `Icon` for both bindings and forms using a relative path.

Please note that no validation of the asset is done due to performance concerns. Invalid icon with show as invalid in the UI. Only malformed path containing e.g. `/../` are logged and ignored.

Tested with hello-world app.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-30595
