### PR TITLE
[MM-36302] Update autocomplete when configuration changes

### DIFF
--- a/server/command/service.go
+++ b/server/command/service.go
@@ -44,7 +44,7 @@ type commandHandler struct {
 	autoComplete *model.AutocompleteData
 }
 
-func (s *service) allCommands(conf config.Config) map[string]commandHandler {
+func (s *service) allSubCommands(conf config.Config) map[string]commandHandler {
 	uninstallAC := model.NewAutocompleteData("uninstall", "", "Uninstall an app")
 	uninstallAC.AddTextArgument("ID of the app to uninstall", "appID", "")
 	uninstallAC.RoleID = model.SYSTEM_ADMIN_ROLE_ID
@@ -200,7 +200,7 @@ func (s *service) Configure(conf config.Config) {
 }
 
 func (s *service) registerCommand(conf config.Config) error {
-	subCommands := s.allCommands(conf)
+	subCommands := s.allSubCommands(conf)
 	var subs []string
 	for t := range subCommands {
 		subs = append(subs, t)
@@ -277,7 +277,7 @@ func (s *service) ExecuteCommand(pluginContext *plugin.Context, commandArgs *mod
 
 func (s *service) handleMain(in *commandParams) (*model.CommandResponse, error) {
 	conf := s.conf.GetConfig()
-	return s.runSubcommand(s.allCommands(conf), in)
+	return s.runSubcommand(s.allSubCommands(conf), in)
 }
 
 func (s *service) runSubcommand(subcommands map[string]commandHandler, params *commandParams) (*model.CommandResponse, error) {

--- a/server/command/service.go
+++ b/server/command/service.go
@@ -18,6 +18,7 @@ import (
 )
 
 type Service interface {
+	config.Configurable
 	ExecuteCommand(pluginContext *plugin.Context, commandArgs *model.CommandArgs) (*model.CommandResponse, error)
 }
 
@@ -43,7 +44,7 @@ type commandHandler struct {
 	autoComplete *model.AutocompleteData
 }
 
-func (s *service) allCommands() map[string]commandHandler {
+func (s *service) allCommands(conf config.Config) map[string]commandHandler {
 	uninstallAC := model.NewAutocompleteData("uninstall", "", "Uninstall an app")
 	uninstallAC.AddTextArgument("ID of the app to uninstall", "appID", "")
 	uninstallAC.RoleID = model.SYSTEM_ADMIN_ROLE_ID
@@ -62,8 +63,6 @@ func (s *service) allCommands() map[string]commandHandler {
 			autoComplete: uninstallAC,
 		},
 	}
-
-	conf := s.conf.GetConfig()
 
 	if conf.DeveloperMode {
 		debugAddManifestAC := model.NewAutocompleteData("debug-add-manifest", "", "Add a manifest to the local list of known apps")
@@ -183,7 +182,25 @@ func MakeService(mm *pluginapi.Client, configService config.Service, proxy proxy
 		proxy:   proxy,
 		httpOut: httpOut,
 	}
-	subCommands := s.allCommands()
+	conf := s.conf.GetConfig()
+
+	err := s.registerCommand(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+func (s *service) Configure(conf config.Config) {
+	err := s.registerCommand(conf)
+	if err != nil {
+		s.mm.Log.Warn("Failed to re-register command", "error", err.Error())
+	}
+}
+
+func (s *service) registerCommand(conf config.Config) error {
+	subCommands := s.allCommands(conf)
 	var subs []string
 	for t := range subCommands {
 		subs = append(subs, t)
@@ -196,18 +213,15 @@ func MakeService(mm *pluginapi.Client, configService config.Service, proxy proxy
 
 	AddACForSubCommands(subCommands, ac)
 
-	err := mm.SlashCommand.Register(&model.Command{
+	err := s.mm.SlashCommand.Register(&model.Command{
 		Trigger:          config.CommandTrigger,
 		AutoComplete:     true,
 		AutoCompleteDesc: "Manage Apps",
 		AutoCompleteHint: fmt.Sprintf("Usage: `/%s info`.", config.CommandTrigger),
 		AutocompleteData: ac,
 	})
-	if err != nil {
-		return nil, err
-	}
 
-	return s, nil
+	return err
 }
 
 func AddACForSubCommands(subCommands map[string]commandHandler, rootAC *model.AutocompleteData) {
@@ -262,7 +276,8 @@ func (s *service) ExecuteCommand(pluginContext *plugin.Context, commandArgs *mod
 }
 
 func (s *service) handleMain(in *commandParams) (*model.CommandResponse, error) {
-	return s.runSubcommand(s.allCommands(), in)
+	conf := s.conf.GetConfig()
+	return s.runSubcommand(s.allCommands(conf), in)
 }
 
 func (s *service) runSubcommand(subcommands map[string]commandHandler, params *commandParams) (*model.CommandResponse, error) {

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -154,7 +154,7 @@ func (p *Plugin) OnConfigurationChange() error {
 	stored := config.StoredConfig{}
 	_ = p.mm.Configuration.LoadPluginConfiguration(&stored)
 
-	return p.conf.Reconfigure(stored, p.store.App, p.store.Manifest)
+	return p.conf.Reconfigure(stored, p.store.App, p.store.Manifest, p.command)
 }
 
 func (p *Plugin) ExecuteCommand(c *plugin.Context, args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {


### PR DESCRIPTION
#### Summary
In order for the slash command autocomplete to update the command service needs to re-register the slash command.

I'm not entirely happy with the `Plugin` taking care of deciding which services need to `Reconfigure`. Rather the services register them self at the config store for a `Reconfigure`. But the change seems extends the scope of this PR.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36302

