### PR TITLE
[MM-36659] Check for valid HomepageURL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,10 @@ GO_BUILD_FLAGS ?=
 MM_UTILITIES_DIR ?= ../mattermost-utilities
 DLV_DEBUG_PORT := 2346
 
-
 export GO111MODULE=on
 
 MINIMUM_SUPPORTED_GO_MAJOR_VERSION = 1
-MINIMUM_SUPPORTED_GO_MINOR_VERSION = 12
+MINIMUM_SUPPORTED_GO_MINOR_VERSION = 16
 GO_MAJOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1)
 GO_MINOR_VERSION = $(shell $(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f2)
 GO_VERSION_VALIDATION_ERR_MSG = Golang version is not supported, please update to at least $(MINIMUM_SUPPORTED_GO_MAJOR_VERSION).$(MINIMUM_SUPPORTED_GO_MINOR_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ LDFLAGS += -X "main.BuildHash=$(BUILD_HASH)"
 LDFLAGS += -X "main.BuildHashShort=$(BUILD_HASH_SHORT)"
 GO_BUILD_FLAGS += -ldflags '$(LDFLAGS)'
 GO_TEST_FLAGS += -ldflags '$(LDFLAGS)'
-GO_PACKAGES = $(shell go list ./...)
 
 # You can include assets this directory into the bundle. This can be e.g. used to include profile pictures.
 ASSETS_DIR ?= assets
@@ -253,13 +252,13 @@ endif
 .PHONY: test-e2e
 test-e2e: dist
 	@echo Running e2e tests
-	PLUGIN_BUNDLE=$(shell pwd)/dist/$(BUNDLE_NAME) $(GO) test -v $(GO_TEST_FLAGS) -tags=e2e $(GO_PACKAGES)
+	PLUGIN_BUNDLE=$(shell pwd)/dist/$(BUNDLE_NAME) $(GO) test -v $(GO_TEST_FLAGS) -tags=e2e ./...
 
 ## Creates a coverage report for the server code.
 .PHONY: coverage
 coverage: webapp/node_modules
 ifneq ($(HAS_SERVER),)
-	$(GO) test $(GO_TEST_FLAGS) -coverprofile=server/coverage.txt ./server/...
+	$(GO) test $(GO_TEST_FLAGS) -coverprofile=server/coverage.txt ./...
 	$(GO) tool cover -html=server/coverage.txt
 endif
 

--- a/apps/app_test.go
+++ b/apps/app_test.go
@@ -34,3 +34,30 @@ func TestAppIDIsValid(t *testing.T) {
 		})
 	}
 }
+
+func TestAppVersionIsValid(t *testing.T) {
+	t.Parallel()
+
+	for id, valid := range map[string]bool{
+		"":            true,
+		"v1.0.0":      true,
+		"1.0.0":       true,
+		"v1.0.0-rc1":  true,
+		"1.0.0-rc1":   true,
+		"CAPS-OK":     true,
+		".DOTS.":      true,
+		"-SLASHES-":   true,
+		"_OK_":        true,
+		"v00_00_0000": false,
+		"/":           false,
+	} {
+		t.Run(id, func(t *testing.T) {
+			err := AppVersion(id).IsValid()
+			if valid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}

--- a/apps/manifest.go
+++ b/apps/manifest.go
@@ -132,11 +132,11 @@ func (f AWSLambda) IsValid() error {
 	if f.Name == "" {
 		return utils.NewInvalidError("aws_lambda name must not be empty")
 	}
-	if f.Runtime == "" {
-		return utils.NewInvalidError("aws_lambda runtime must not be empty")
-	}
 	if f.Handler == "" {
 		return utils.NewInvalidError("aws_lambda handler must not be empty")
+	}
+	if f.Runtime == "" {
+		return utils.NewInvalidError("aws_lambda runtime must not be empty")
 	}
 	return nil
 }
@@ -183,6 +183,15 @@ func (m Manifest) IsValid() error {
 		}
 	}
 
+	if m.HomepageURL == "" {
+		return utils.NewInvalidError(errors.New("homepage_url is empty"))
+	}
+
+	_, err := url.Parse(m.HomepageURL)
+	if err != nil {
+		return utils.NewInvalidError(errors.Wrapf(err, "homepage_url invalid: %q", m.HomepageURL))
+	}
+
 	if m.Icon != "" {
 		_, err := utils.CleanStaticPath(m.Icon)
 		if err != nil {
@@ -192,6 +201,10 @@ func (m Manifest) IsValid() error {
 
 	switch m.AppType {
 	case AppTypeHTTP:
+		if m.HTTPRootURL == "" {
+			return utils.NewInvalidError(errors.New("root_url must be set for HTTP apps"))
+		}
+
 		_, err := url.Parse(m.HTTPRootURL)
 		if err != nil {
 			return utils.NewInvalidError(errors.Wrapf(err, "invalid root_url: %q", m.HTTPRootURL))

--- a/apps/manifest.go
+++ b/apps/manifest.go
@@ -2,7 +2,6 @@ package apps
 
 import (
 	"encoding/json"
-	"net/url"
 
 	"github.com/pkg/errors"
 
@@ -187,8 +186,7 @@ func (m Manifest) IsValid() error {
 		return utils.NewInvalidError(errors.New("homepage_url is empty"))
 	}
 
-	_, err := url.Parse(m.HomepageURL)
-	if err != nil {
+	if err := utils.IsValidHTTPURL(m.HomepageURL); err != nil {
 		return utils.NewInvalidError(errors.Wrapf(err, "homepage_url invalid: %q", m.HomepageURL))
 	}
 
@@ -205,7 +203,7 @@ func (m Manifest) IsValid() error {
 			return utils.NewInvalidError(errors.New("root_url must be set for HTTP apps"))
 		}
 
-		_, err := url.Parse(m.HTTPRootURL)
+		err := utils.IsValidHTTPURL(m.HTTPRootURL)
 		if err != nil {
 			return utils.NewInvalidError(errors.Wrapf(err, "invalid root_url: %q", m.HTTPRootURL))
 		}

--- a/apps/manifest_test.go
+++ b/apps/manifest_test.go
@@ -1,0 +1,166 @@
+package apps_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mattermost/mattermost-plugin-apps/apps"
+)
+
+func TestManifestIsValid(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		Manifest      apps.Manifest
+		ExpectedError bool
+	}{
+		"empty manifest": {
+			Manifest:      apps.Manifest{},
+			ExpectedError: true,
+		},
+		"missing app type": {
+			Manifest: apps.Manifest{
+				AppID:       "abc",
+				HomepageURL: "https://example.org",
+			},
+			ExpectedError: true,
+		},
+		"HomepageURL empty": {
+			Manifest: apps.Manifest{
+				AppID:       "abc",
+				AppType:     apps.AppTypeHTTP,
+				HTTPRootURL: "https://example.org/root",
+			},
+			ExpectedError: true,
+		},
+		"HTTPRootURL empty": {
+			Manifest: apps.Manifest{
+				AppID:       "abc",
+				AppType:     apps.AppTypeHTTP,
+				HomepageURL: "https://example.org",
+			},
+			ExpectedError: true,
+		},
+		"minimal valid HTTP app example manifest": {
+			Manifest: apps.Manifest{
+				AppID:       "abc",
+				AppType:     apps.AppTypeHTTP,
+				HomepageURL: "https://example.org",
+				HTTPRootURL: "https://example.org/root",
+			},
+			ExpectedError: false,
+		},
+		"invalid Icon": {
+			Manifest: apps.Manifest{
+				AppID:       "abc",
+				AppType:     apps.AppTypeHTTP,
+				HomepageURL: "https://example.org",
+				HTTPRootURL: "https://example.org/root",
+				Icon:        "../..",
+			},
+			ExpectedError: true,
+		},
+		"invalid HomepageURL": {
+			Manifest: apps.Manifest{
+				AppID:       "abc",
+				AppType:     apps.AppTypeHTTP,
+				HomepageURL: ":invalid",
+				HTTPRootURL: "https://example.org/root",
+			},
+			ExpectedError: true,
+		},
+		"invalid HTTPRootURL": {
+			Manifest: apps.Manifest{
+				AppID:       "abc",
+				AppType:     apps.AppTypeHTTP,
+				HomepageURL: "https://example.org/root",
+				HTTPRootURL: ":invalid",
+			},
+			ExpectedError: true,
+		},
+		"no lambda for AWS app": {
+			Manifest: apps.Manifest{
+				AppID:       "abc",
+				AppType:     apps.AppTypeAWSLambda,
+				HomepageURL: "https://example.org",
+			},
+			ExpectedError: true,
+		},
+		"missing path for AWS app": {
+			Manifest: apps.Manifest{
+				AppID:       "abc",
+				AppType:     apps.AppTypeAWSLambda,
+				HomepageURL: "https://example.org",
+				AWSLambda: []apps.AWSLambda{{
+					Name:    "go-funcion",
+					Handler: "hello-lambda",
+					Runtime: "go1.x",
+				}},
+			},
+			ExpectedError: true,
+		},
+		"missing name for AWS app": {
+			Manifest: apps.Manifest{
+				AppID:       "abc",
+				AppType:     apps.AppTypeAWSLambda,
+				HomepageURL: "https://example.org",
+				AWSLambda: []apps.AWSLambda{{
+					Path:    "/",
+					Handler: "hello-lambda",
+					Runtime: "go1.x",
+				}},
+			},
+			ExpectedError: true,
+		},
+		"missing handler for AWS app": {
+			Manifest: apps.Manifest{
+				AppID:       "abc",
+				AppType:     apps.AppTypeAWSLambda,
+				HomepageURL: "https://example.org",
+				AWSLambda: []apps.AWSLambda{{
+					Path:    "/",
+					Name:    "go-funcion",
+					Runtime: "go1.x",
+				}},
+			},
+			ExpectedError: true,
+		},
+		"missing runtime for AWS app": {
+			Manifest: apps.Manifest{
+				AppID:       "abc",
+				AppType:     apps.AppTypeAWSLambda,
+				HomepageURL: "https://example.org",
+				AWSLambda: []apps.AWSLambda{{
+					Path:    "/",
+					Name:    "go-funcion",
+					Handler: "hello-lambda",
+				}},
+			},
+			ExpectedError: true,
+		},
+		"minimal valid AWS app example manifest": {
+			Manifest: apps.Manifest{
+				AppID:       "abc",
+				AppType:     apps.AppTypeAWSLambda,
+				HomepageURL: "https://example.org",
+				AWSLambda: []apps.AWSLambda{{
+					Path:    "/",
+					Name:    "go-funcion",
+					Handler: "hello-lambda",
+					Runtime: "go1.x",
+				}},
+			},
+			ExpectedError: false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := test.Manifest.IsValid()
+			if test.ExpectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/apps/manifest_test.go
+++ b/apps/manifest_test.go
@@ -156,6 +156,7 @@ func TestManifestIsValid(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			err := test.Manifest.IsValid()
+
 			if test.ExpectedError {
 				assert.Error(t, err)
 			} else {

--- a/utils/url.go
+++ b/utils/url.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+func IsValidHTTPURL(rawUrl string) error {
+	u, err := url.ParseRequestURI(rawUrl)
+	if err != nil {
+		return err
+	}
+
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return errors.Errorf("URL schema must either be %q or %q", "http", "https")
+	}
+
+	if u.Host == "" {
+		return errors.New("URL must contain a host")
+	}
+
+	return nil
+}

--- a/utils/url.go
+++ b/utils/url.go
@@ -6,8 +6,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-func IsValidHTTPURL(rawUrl string) error {
-	u, err := url.ParseRequestURI(rawUrl)
+// IsValidHTTPURL checks if a given URL is a valid URL with a host and a http or http scheme.
+func IsValidHTTPURL(rawURL string) error {
+	u, err := url.ParseRequestURI(rawURL)
 	if err != nil {
 		return err
 	}

--- a/utils/url_test.go
+++ b/utils/url_test.go
@@ -1,0 +1,82 @@
+package utils_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mattermost/mattermost-plugin-apps/utils"
+)
+
+func TestIsValidHttpUrl(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		URL           string
+		ExpectedError bool
+	}{
+
+		"empty url": {
+			"",
+			true,
+		},
+		"bad url": {
+			"bad url",
+			true,
+		},
+		"relative url": {
+			"/api/test",
+			true,
+		},
+		"relative url ending with slash": {
+			"/some/url/",
+			true,
+		},
+		"url with invalid scheme": {
+			"htp://mattermost.com",
+			true,
+		},
+		"url with just http": {
+			"http://",
+			true,
+		},
+		"url with just https": {
+			"https://",
+			true,
+		},
+		"url with extra slashes": {
+			"https:///mattermost.com",
+			true,
+		},
+		"correct url with http scheme": {
+			"http://mattemost.com",
+			false,
+		},
+		"correct url with https scheme": {
+			"https://mattermost.com/api/test",
+			false,
+		},
+		"correct url with port": {
+			"https://localhost:8080/test",
+			false,
+		},
+		"correct url without scheme": {
+			"mattermost.com/some/url/",
+			true,
+		},
+		"correct url with extra slashes": {
+			"https://mattermost.com/some//url",
+			false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := utils.IsValidHTTPURL(test.URL)
+
+			if test.ExpectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Summary
Every apps needs to have a valid `HomepageURL`. This is now checked and verified. HTTP apps also need an `HTTPRootURL`.

The PR also fixes two build issue:
- The minimum go version needs to be 1.6
- All `go test` command should run against all packages, not only the ones in `./server`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36659
