### PR TITLE
[MM-3384] wrap manifest json data read error with better description

### DIFF
--- a/server/command/install.go
+++ b/server/command/install.go
@@ -74,7 +74,7 @@ func (s *service) executeInstallHTTP(params *commandParams) (*model.CommandRespo
 
 	m, err := apps.ManifestFromJSON(data)
 	if err != nil {
-		return errorOut(params, err)
+		return errorOut(params, errors.Wrap(err, "unable to read `manifest json` from "+manifestURL))
 	}
 
 	_, err = s.proxy.AddLocalManifest(params.commandArgs.UserId, m)

--- a/server/command/install.go
+++ b/server/command/install.go
@@ -74,7 +74,7 @@ func (s *service) executeInstallHTTP(params *commandParams) (*model.CommandRespo
 
 	m, err := apps.ManifestFromJSON(data)
 	if err != nil {
-		return errorOut(params, errors.Wrap(err, "unable to read `manifest json` from "+manifestURL))
+		return errorOut(params, errors.Wrap(err, "unable to decode "+manifestURL))
 	}
 
 	_, err = s.proxy.AddLocalManifest(params.commandArgs.UserId, m)


### PR DESCRIPTION
#### Summary
When a use tries installing an app with an invalid manifest data, the following error is presented.
![image](https://user-images.githubusercontent.com/7575921/126646893-d308cbb9-2682-4c31-a64e-329344b83741.png)

This PR wraps the error with a more informative error.
![image](https://user-images.githubusercontent.com/7575921/126676938-b4ea3626-c0d3-4b35-a6fc-b267a5612719.png)


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37339