### PR TITLE
Fix issue with creating bot with existing user account

### DIFF
--- a/server/proxy/install.go
+++ b/server/proxy/install.go
@@ -165,6 +165,17 @@ func (p *Proxy) ensureBot(client mmclient.Client, app *apps.App) error {
 				return err
 			}
 		}
+
+		_, err := client.GetBot(user.Id)
+		if err != nil {
+			err = client.CreateBot(bot)
+			if err != nil {
+				return err
+			}
+		} else {
+			bot.UserId = user.Id
+			bot.Username = user.Username
+		}
 	}
 	app.BotUserID = bot.UserId
 	app.BotUsername = bot.Username


### PR DESCRIPTION
#### Summary

If the bot user exists and is enabled, the bot account creation process messed up because there is no "full" bot struct after these checks. The bot struct instance was missing the user ID and username, so the `App` struct was missing these values. This was causing issues with the bot info never existing on the `App` struct after installation.

#### Ticket Link

