### PR TITLE
Update ci to run hello app within cypress step instead of its own step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,10 +152,6 @@ jobs:
       - run:
           name: Install Apps plugin
           command: make deploy
-      - run:
-          name: Start hello-world App
-          command: make hello_world
-          background: true
       - *save_go_cache
       - *restore_cypress_cache
       - run:
@@ -164,6 +160,7 @@ jobs:
           command: |
             export FAILURE_MESSAGE="At least one test has failed."
             export RESULTS_OUTPUT="results-output.txt"
+            make hello_world &
             cd e2e && npm install && npm run test |& tee $RESULTS_OUTPUT; if grep "$FAILURE_MESSAGE" "$RESULTS_OUTPUT"; then exit 1; fi
       - *save_cypress_cache
       - store_artifacts:
@@ -256,10 +253,6 @@ jobs:
       - run:
           name: Install Apps plugin
           command: make deploy
-      - run:
-          name: Start hello-world App
-          command: make hello_world
-          background: true
       - *save_go_cache
       - *restore_cypress_cache
       - run:
@@ -268,6 +261,7 @@ jobs:
           command: |
             export FAILURE_MESSAGE="At least one test has failed."
             export RESULTS_OUTPUT="results-output.txt"
+            make hello_world &
             cd e2e && npm install && npm run test |& tee $RESULTS_OUTPUT; if grep "$FAILURE_MESSAGE" "$RESULTS_OUTPUT"; then exit 1; fi
       - *save_cypress_cache
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,6 +152,9 @@ jobs:
       - run:
           name: Install Apps plugin
           command: make deploy
+      - run:
+          name: Start hello-world App
+          command: make hello_world &
       - *save_go_cache
       - *restore_cypress_cache
       - run:
@@ -160,7 +163,6 @@ jobs:
           command: |
             export FAILURE_MESSAGE="At least one test has failed."
             export RESULTS_OUTPUT="results-output.txt"
-            make hello_world &
             cd e2e && npm install && npm run test |& tee $RESULTS_OUTPUT; if grep "$FAILURE_MESSAGE" "$RESULTS_OUTPUT"; then exit 1; fi
       - *save_cypress_cache
       - store_artifacts:
@@ -253,6 +255,9 @@ jobs:
       - run:
           name: Install Apps plugin
           command: make deploy
+      - run:
+          name: Start hello-world App
+          command: make hello_world
       - *save_go_cache
       - *restore_cypress_cache
       - run:
@@ -261,7 +266,6 @@ jobs:
           command: |
             export FAILURE_MESSAGE="At least one test has failed."
             export RESULTS_OUTPUT="results-output.txt"
-            make hello_world &
             cd e2e && npm install && npm run test |& tee $RESULTS_OUTPUT; if grep "$FAILURE_MESSAGE" "$RESULTS_OUTPUT"; then exit 1; fi
       - *save_cypress_cache
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,9 +152,6 @@ jobs:
       - run:
           name: Install Apps plugin
           command: make deploy
-      - run:
-          name: Start hello-world App
-          command: make hello_world &
       - *save_go_cache
       - *restore_cypress_cache
       - run:
@@ -163,6 +160,7 @@ jobs:
           command: |
             export FAILURE_MESSAGE="At least one test has failed."
             export RESULTS_OUTPUT="results-output.txt"
+            make hello_world &
             cd e2e && npm install && npm run test |& tee $RESULTS_OUTPUT; if grep "$FAILURE_MESSAGE" "$RESULTS_OUTPUT"; then exit 1; fi
       - *save_cypress_cache
       - store_artifacts:
@@ -255,9 +253,6 @@ jobs:
       - run:
           name: Install Apps plugin
           command: make deploy
-      - run:
-          name: Start hello-world App
-          command: make hello_world
       - *save_go_cache
       - *restore_cypress_cache
       - run:
@@ -266,6 +261,7 @@ jobs:
           command: |
             export FAILURE_MESSAGE="At least one test has failed."
             export RESULTS_OUTPUT="results-output.txt"
+            make hello_world &
             cd e2e && npm install && npm run test |& tee $RESULTS_OUTPUT; if grep "$FAILURE_MESSAGE" "$RESULTS_OUTPUT"; then exit 1; fi
       - *save_cypress_cache
       - store_artifacts:


### PR DESCRIPTION
#### Summary

This PR is a followup to https://github.com/mattermost/mattermost-plugin-apps/pull/235#discussion_r689776274, which notes that the hello app does not need to be run as a separate step than the tests running.