### PR TITLE
Add homepage_url to example app to fix CI

### DIFF
--- a/examples/js/hello-world/app.js
+++ b/examples/js/hello-world/app.js
@@ -15,6 +15,7 @@ app.get('/manifest.json', (req, res) => {
         app_type: 'http',
         icon: 'icon.png',
         root_url: 'http://localhost:8080',
+        homepage_url: 'https://github.com/mattermost/mattermost-plugin-apps/tree/master/examples/js/hello-world',
         requested_permissions: [
             'act_as_bot',
         ],


### PR DESCRIPTION
#### Summary

I'm not sure how this was passing on CI on the previous PRs. There was a breaking change between 0.7 and 0.8 that requires Apps to have a `homepage_url`, and the example App was not updated at that time.