### PR TITLE
Change selector for e2e test

### DIFF
--- a/e2e/cypress/integration/bindings/channel_header_spec.ts
+++ b/e2e/cypress/integration/bindings/channel_header_spec.ts
@@ -44,7 +44,7 @@ describe('Apps bindings - Channel header', () => {
         installHTTPHello();
 
         // # Open the apps modal by clicking on a channel header binding
-        cy.get('#channel-header #send-button').first().click();
+        cy.get('#channel-header button[id="/channel_header/send-button"]').first().click();
 
         // # Type into message field of modal form
         cy.findByTestId('message').type('the test message');

--- a/e2e/cypress/integration/bindings/channel_header_spec.ts
+++ b/e2e/cypress/integration/bindings/channel_header_spec.ts
@@ -44,7 +44,7 @@ describe('Apps bindings - Channel header', () => {
         installHTTPHello();
 
         // # Open the apps modal by clicking on a channel header binding
-        cy.get('#channel-header button[id="/channel_header/send-button"]').first().click();
+        cy.get('#channel-header img[src="http://localhost:8065/plugins/com.mattermost.apps/apps/hello-world/static/icon.png"]').first().click();
 
         // # Type into message field of modal form
         cy.findByTestId('message').type('the test message');


### PR DESCRIPTION
#### Summary

With recent changes to the webapp, the fully qualified `locations` are fixed for each binding. This has made it so the `id` of the buttons rendered have changed. For a channel header binding with `location` `send-button`, the new `location` is now `/channel_header/send-button`. ~~This PR updates the e2e test to use this new `id`.~~

Edit: Updating the selector to use a new id doesn't work because the CI for individual PRs in this repo doesn't use `mattermost-webapp@master`. The selector in the e2e test is now using the channel header button's `img` `src` attribute to find the element to click.

I've made a [ticket](https://mattermost.atlassian.net/browse/MM-38022) to make sure these id's are namespaced to specific Apps. The current state goes against the HTML spec of enforcing unique id's. It doesn't break anything but is incorrect and would make accessibility better if we included some identifier for the app in the `id`, or just remove the `id` and use another mechanism in the test to find these elements.