### PR TITLE
[MM-37242] Add comment explaining why /apps list is public

### DIFF
--- a/server/command/list.go
+++ b/server/command/list.go
@@ -25,6 +25,8 @@ func (s *service) executeList(params *commandParams) (*model.CommandResponse, er
 	listed := s.proxy.GetListedApps("", includePluginApps)
 	installed := s.proxy.GetInstalledApps()
 
+	// All of this information is non sensitive.
+	// Checks for the user's permissions might be needed in the future.
 	txt := "| Name | Status | Type | Version | Account | Locations | Permissions |\n"
 	txt += "| :-- |:-- | :-- | :-- | :-- | :-- | :-- |\n"
 


### PR DESCRIPTION
#### Summary
Add comment explaining why `/apps list` is public. This ensure that information that will be added in the futures is carefully checked.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37242