### PR TITLE
[MM-38153] Allow test-e2e to run all tests

### DIFF
--- a/apps/call_test.go
+++ b/apps/call_test.go
@@ -1,5 +1,3 @@
-// +build !e2e
-
 package apps
 
 import (

--- a/server/httpin/restapi/kv_test.go
+++ b/server/httpin/restapi/kv_test.go
@@ -1,5 +1,3 @@
-// +build !e2e
-
 package restapi
 
 import (

--- a/server/proxy/bindings_test.go
+++ b/server/proxy/bindings_test.go
@@ -1,5 +1,3 @@
-// +build !e2e
-
 package proxy
 
 import (

--- a/server/store/service_test.go
+++ b/server/store/service_test.go
@@ -1,5 +1,3 @@
-// +build !e2e
-
 package store
 
 import (

--- a/server/store/subscriptions_test.go
+++ b/server/store/subscriptions_test.go
@@ -1,5 +1,3 @@
-// +build !e2e
-
 package store
 
 import (

--- a/utils/httputils/limited_readcloser_test.go
+++ b/utils/httputils/limited_readcloser_test.go
@@ -1,6 +1,5 @@
 // Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
 // See License for license information.
-// +build !e2e
 
 package httputils
 

--- a/utils/httputils/utils_test.go
+++ b/utils/httputils/utils_test.go
@@ -1,6 +1,5 @@
 // Copyright (c) 2019-present Mattermost, Inc. All Rights Reserved.
 // See License for license information.
-// +build !e2e
 
 package httputils
 


### PR DESCRIPTION
#### Summary
This PR allows running all test using `make test-e2e` by removing the build tags for the non e2e tests. It also allows for easier developing as a developer can now set the local build tags to `e2e` and compile all files.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38153
