### PR TITLE
[MM-33770] Use permssion specific client to expands calls

### DIFF
--- a/server/command/service.go
+++ b/server/command/service.go
@@ -358,7 +358,7 @@ func (s *service) newCommandContext(commandArgs *model.CommandArgs) *apps.Contex
 }
 
 func (s *service) newMMClient(commandArgs *model.CommandArgs) (mmclient.Client, error) {
-	return mmclient.NewHTTPClient(s.conf, commandArgs.Session.Id, commandArgs.UserId)
+	return mmclient.NewHTTPClientFromSessionID(s.conf, commandArgs.Session.Id, commandArgs.UserId)
 }
 
 func out(params *commandParams, out string) (*model.CommandResponse, error) {

--- a/server/httpin/dialog/install.go
+++ b/server/httpin/dialog/install.go
@@ -158,7 +158,7 @@ func (d *dialog) handleInstall(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	client, err := mmclient.NewHTTPClient(d.conf, sessionID, actingUserID)
+	client, err := mmclient.NewHTTPClientFromSessionID(d.conf, sessionID, actingUserID)
 	if err != nil {
 		httputils.WriteError(w, errors.Wrap(utils.ErrInvalid, "invalid session"))
 		return

--- a/server/httpin/restapi/app.go
+++ b/server/httpin/restapi/app.go
@@ -59,7 +59,7 @@ func (a *restapi) handleEnableApp(w http.ResponseWriter, r *http.Request, plugin
 		client = mmclient.NewRPCClient(mm)
 	} else {
 		var err error
-		client, err = mmclient.NewHTTPClient(a.conf, sessionID, actingUserID)
+		client, err = mmclient.NewHTTPClientFromSessionID(a.conf, sessionID, actingUserID)
 		if err != nil {
 			httputils.WriteError(w, errors.Wrap(utils.ErrInvalid, "invalid session"))
 			return
@@ -101,7 +101,7 @@ func (a *restapi) handleDisableApp(w http.ResponseWriter, r *http.Request, plugi
 		client = mmclient.NewRPCClient(mm)
 	} else {
 		var err error
-		client, err = mmclient.NewHTTPClient(a.conf, sessionID, actingUserID)
+		client, err = mmclient.NewHTTPClientFromSessionID(a.conf, sessionID, actingUserID)
 		if err != nil {
 			httputils.WriteError(w, errors.Wrap(utils.ErrInvalid, "invalid session"))
 			return
@@ -143,7 +143,7 @@ func (a *restapi) handleInstallApp(w http.ResponseWriter, r *http.Request, plugi
 	if pluginID != "" {
 		client = mmclient.NewRPCClient(mm)
 	} else {
-		client, err = mmclient.NewHTTPClient(a.conf, sessionID, actingUserID)
+		client, err = mmclient.NewHTTPClientFromSessionID(a.conf, sessionID, actingUserID)
 		if err != nil {
 			httputils.WriteError(w, errors.Wrap(utils.ErrInvalid, "invalid session"))
 			return
@@ -191,7 +191,7 @@ func (a *restapi) handleUninstallApp(w http.ResponseWriter, r *http.Request, plu
 		client = mmclient.NewRPCClient(mm)
 	} else {
 		var err error
-		client, err = mmclient.NewHTTPClient(a.conf, sessionID, actingUserID)
+		client, err = mmclient.NewHTTPClientFromSessionID(a.conf, sessionID, actingUserID)
 		if err != nil {
 			httputils.WriteError(w, errors.Wrap(utils.ErrInvalid, "invalid session"))
 			return

--- a/server/mmclient/client.go
+++ b/server/mmclient/client.go
@@ -5,9 +5,16 @@ import (
 )
 
 type Client interface {
+	GetUser(userID string) (*model.User, error)
 	GetUserByUsername(userName string) (*model.User, error)
 	CreateUserAccessToken(userID, description string) (*model.UserAccessToken, error)
 	RevokeUserAccessToken(tokenID string) error
+
+	GetChannel(channelID string) (*model.Channel, error)
+
+	GetTeam(teamID string) (*model.Team, error)
+
+	GetPost(postID string) (*model.Post, error)
 
 	CreateOAuthApp(app *model.OAuthApp) error
 	GetOAuthApp(appID string) (*model.OAuthApp, error)

--- a/server/mmclient/http.go
+++ b/server/mmclient/http.go
@@ -11,7 +11,7 @@ type httpClient struct {
 	mm *model.Client4
 }
 
-func NewHTTPClient(config config.Service, sessionID, actingUserID string) (Client, error) {
+func NewHTTPClientFromSessionID(config config.Service, sessionID, actingUserID string) (Client, error) {
 	conf, mm, _ := config.Basic()
 	client, err := utils.ClientFromSession(mm, conf.MattermostSiteURL, sessionID, actingUserID)
 	if err != nil {
@@ -21,7 +21,25 @@ func NewHTTPClient(config config.Service, sessionID, actingUserID string) (Clien
 	return &httpClient{client}, nil
 }
 
+func NewHTTPClientFromToken(config config.Service, token, actingUserID string) (Client, error) {
+	conf := config.Get()
+
+	client := model.NewAPIv4Client(conf.MattermostSiteURL)
+	client.SetToken(token)
+
+	return &httpClient{client}, nil
+}
+
 // User section
+
+func (h *httpClient) GetUser(userID string) (*model.User, error) {
+	user, resp := h.mm.GetUser(userID, "")
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+
+	return user, nil
+}
 
 func (h *httpClient) GetUserByUsername(userName string) (*model.User, error) {
 	user, resp := h.mm.GetUserByUsername(userName, "")
@@ -48,6 +66,39 @@ func (h *httpClient) RevokeUserAccessToken(tokenID string) error {
 	}
 
 	return nil
+}
+
+// Channel section
+
+func (h *httpClient) GetChannel(channelID string) (*model.Channel, error) {
+	channel, resp := h.mm.GetChannel(channelID, "")
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+
+	return channel, nil
+}
+
+// Team section
+
+func (h *httpClient) GetTeam(teamID string) (*model.Team, error) {
+	team, resp := h.mm.GetTeam(teamID, "")
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+
+	return team, nil
+}
+
+// Post section
+
+func (h *httpClient) GetPost(postID string) (*model.Post, error) {
+	post, resp := h.mm.GetPost(postID, "")
+	if resp.Error != nil {
+		return nil, resp.Error
+	}
+
+	return post, nil
 }
 
 // OAuth section

--- a/server/mmclient/rpc.go
+++ b/server/mmclient/rpc.go
@@ -15,6 +15,10 @@ func NewRPCClient(c *pluginapi.Client) Client {
 
 // User section
 
+func (r *rpcClient) GetUser(userID string) (*model.User, error) {
+	return r.mm.User.Get(userID)
+}
+
 func (r *rpcClient) GetUserByUsername(userName string) (*model.User, error) {
 	return r.mm.User.GetByUsername(userName)
 }
@@ -25,6 +29,24 @@ func (r *rpcClient) CreateUserAccessToken(userID, description string) (*model.Us
 
 func (r *rpcClient) RevokeUserAccessToken(tokenID string) error {
 	return r.mm.User.RevokeAccessToken(tokenID)
+}
+
+// Channel section
+
+func (r *rpcClient) GetChannel(channelID string) (*model.Channel, error) {
+	return r.mm.Channel.Get(channelID)
+}
+
+// Team section
+
+func (r *rpcClient) GetTeam(teamID string) (*model.Team, error) {
+	return r.mm.Team.Get(teamID)
+}
+
+// Post section
+
+func (r *rpcClient) GetPost(postID string) (*model.Post, error) {
+	return r.mm.Post.GetPost(postID)
 }
 
 // OAuth section

--- a/server/proxy/expand.go
+++ b/server/proxy/expand.go
@@ -58,6 +58,7 @@ func (e *expander) ExpandForApp(app *apps.App, expand *apps.Expand) (*apps.Conte
 		client = mmclient.NewRPCClient(mm)
 	case app.GrantedPermissions.Contains(apps.PermissionActAsUser):
 		var err error
+		// The OAuth2 token should be used here once it's implemented
 		client, err = mmclient.NewHTTPClientFromSessionID(e.conf, e.sessionID, e.ActingUserID)
 		if err != nil {
 			return nil, utils.NewUnauthorizedError(err)

--- a/server/proxy/expand.go
+++ b/server/proxy/expand.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mattermost/mattermost-plugin-apps/apps"
 	"github.com/mattermost/mattermost-plugin-apps/server/config"
+	"github.com/mattermost/mattermost-plugin-apps/server/mmclient"
 	"github.com/mattermost/mattermost-plugin-apps/server/store"
 	"github.com/mattermost/mattermost-plugin-apps/utils"
 )
@@ -50,6 +51,27 @@ func (e *expander) ExpandForApp(app *apps.App, expand *apps.Expand) (*apps.Conte
 		return &clone, nil
 	}
 
+	var client mmclient.Client
+	switch {
+	case app.GrantedPermissions.Contains(apps.PermissionActAsAdmin):
+		// If the app has admin permission anyway, use the RPC client for performance reasons
+		client = mmclient.NewRPCClient(mm)
+	case app.GrantedPermissions.Contains(apps.PermissionActAsUser):
+		var err error
+		client, err = mmclient.NewHTTPClientFromSessionID(e.conf, e.sessionID, e.ActingUserID)
+		if err != nil {
+			return nil, utils.NewUnauthorizedError(err)
+		}
+	case app.GrantedPermissions.Contains(apps.PermissionActAsBot):
+		var err error
+		client, err = mmclient.NewHTTPClientFromToken(e.conf, e.BotAccessToken, e.BotUserID)
+		if err != nil {
+			return nil, utils.NewUnauthorizedError(err)
+		}
+	default:
+		return nil, utils.NewUnauthorizedError("apps without any ActAs* permission can't expand")
+	}
+
 	// TODO: use the appropriate user's Mattermost OAuth2 token once
 	// re-implemented, for now pass in the session token to make things work.
 	if expand.AdminAccessToken != "" || expand.ActingUserAccessToken != "" {
@@ -82,7 +104,7 @@ func (e *expander) ExpandForApp(app *apps.App, expand *apps.Expand) (*apps.Conte
 	clone.ExpandedContext.App = stripApp(app, expand.App)
 
 	if expand.ActingUser != "" && e.ActingUserID != "" && e.ActingUser == nil {
-		actingUser, err := mm.User.Get(e.ActingUserID)
+		actingUser, err := client.GetUser(e.ActingUserID)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to expand acting user %s", e.ActingUserID)
 		}
@@ -91,7 +113,7 @@ func (e *expander) ExpandForApp(app *apps.App, expand *apps.Expand) (*apps.Conte
 	clone.ExpandedContext.ActingUser = stripUser(e.ActingUser, expand.ActingUser)
 
 	if expand.Channel != "" && e.ChannelID != "" && e.Channel == nil {
-		ch, err := mm.Channel.Get(e.ChannelID)
+		ch, err := client.GetChannel(e.ChannelID)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to expand channel %s", e.ChannelID)
 		}
@@ -100,7 +122,7 @@ func (e *expander) ExpandForApp(app *apps.App, expand *apps.Expand) (*apps.Conte
 	clone.ExpandedContext.Channel = stripChannel(e.Channel, expand.Channel)
 
 	if expand.Post != "" && e.PostID != "" && e.Post == nil {
-		post, err := mm.Post.GetPost(e.PostID)
+		post, err := client.GetPost(e.PostID)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to expand post %s", e.PostID)
 		}
@@ -109,7 +131,7 @@ func (e *expander) ExpandForApp(app *apps.App, expand *apps.Expand) (*apps.Conte
 	clone.ExpandedContext.Post = stripPost(e.Post, expand.Post)
 
 	if expand.RootPost != "" && e.RootPostID != "" && e.RootPost == nil {
-		post, err := mm.Post.GetPost(e.RootPostID)
+		post, err := client.GetPost(e.RootPostID)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to expand root post %s", e.RootPostID)
 		}
@@ -118,7 +140,7 @@ func (e *expander) ExpandForApp(app *apps.App, expand *apps.Expand) (*apps.Conte
 	clone.ExpandedContext.RootPost = stripPost(e.RootPost, expand.RootPost)
 
 	if expand.Team != "" && e.TeamID != "" && e.Team == nil {
-		team, err := mm.Team.Get(e.TeamID)
+		team, err := client.GetTeam(e.TeamID)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to expand team %s", e.TeamID)
 		}
@@ -130,7 +152,7 @@ func (e *expander) ExpandForApp(app *apps.App, expand *apps.Expand) (*apps.Conte
 	// https://mattermost.atlassian.net/browse/MM-30403
 
 	if expand.User != "" && e.UserID != "" && e.User == nil {
-		user, err := mm.User.Get(e.UserID)
+		user, err := client.GetUser(e.UserID)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to expand user %s", e.UserID)
 		}


### PR DESCRIPTION
#### Summary
Before this PR apps could expand call to access resources they would not have access otherwise. This PR prevents that by using a permission specific client to expand the calls.

For apps that have the `PermissionActAsAdmin` permission the RPC client is used. If `PermissionActAsUser` is granted, an HTTP client with the users session is used. For `PermissionActAsBot` an HTTP client with the bot session is used.

I've opted for this approach because the apps plugin doesn't need to re-implement the permission checks and just relies on the server to do the right checks.

I tried adding an (go) e2e test for this, but that turned out to be more complicated that I thought. If I get it to work, I will add it later.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33770
