### PR TITLE
[MM-38155] Add recover handler for commands and HTTP requests

### DIFF
--- a/server/command/service.go
+++ b/server/command/service.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"runtime/debug"
 	"sort"
 	"strings"
 
@@ -268,7 +269,7 @@ func AddACForSubCommands(subCommands map[string]commandHandler, rootAC *model.Au
 }
 
 // Handle should be called by the plugin when a command invocation is received from the Mattermost server.
-func (s *service) ExecuteCommand(pluginContext *plugin.Context, commandArgs *model.CommandArgs) (*model.CommandResponse, error) {
+func (s *service) ExecuteCommand(pluginContext *plugin.Context, commandArgs *model.CommandArgs) (resp *model.CommandResponse, err error) {
 	params := &commandParams{
 		pluginContext: pluginContext,
 		commandArgs:   commandArgs,
@@ -299,6 +300,31 @@ func (s *service) ExecuteCommand(pluginContext *plugin.Context, commandArgs *mod
 	}
 
 	params.current = split[1:]
+
+	defer func(log utils.Logger, developerMode bool) {
+		if x := recover(); x != nil {
+			stack := string(debug.Stack())
+
+			log.Errorw(
+				"Recovered from a panic in a command",
+				"command", commandArgs.Command,
+				"error", x,
+				"stack", stack,
+			)
+
+			txt := utils.CodeBlock(commandArgs.Command+"\n") + "Command paniced. "
+
+			if developerMode {
+				txt += fmt.Sprintf("Error: **%v**. Stack:\n%v", x, utils.CodeBlock(stack))
+			} else {
+				txt += "Please check the server logs for more details."
+			}
+			resp = &model.CommandResponse{
+				Text:         txt,
+				ResponseType: model.COMMAND_RESPONSE_TYPE_EPHEMERAL,
+			}
+		}
+	}(s.conf.Logger(), s.conf.Get().DeveloperMode)
 
 	return s.handleMain(params)
 }

--- a/server/httpin/service.go
+++ b/server/httpin/service.go
@@ -1,7 +1,9 @@
 package httpin
 
 import (
+	"fmt"
 	"net/http"
+	"runtime/debug"
 
 	"github.com/gorilla/mux"
 
@@ -10,6 +12,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-apps/server/appservices"
 	"github.com/mattermost/mattermost-plugin-apps/server/config"
 	"github.com/mattermost/mattermost-plugin-apps/server/proxy"
+	"github.com/mattermost/mattermost-plugin-apps/utils"
 )
 
 type Service interface {
@@ -27,10 +30,41 @@ func NewService(router *mux.Router, conf config.Service, proxy proxy.Service, ap
 	for _, f := range initf {
 		f(router, conf, proxy, appServices)
 	}
+	router.Use(recoveryHandler(conf.Logger(), conf.Get().DeveloperMode))
 	router.Handle("{anything:.*}", http.NotFoundHandler())
 
 	return &service{
 		router: router,
+	}
+}
+func recoveryHandler(log utils.Logger, developerMode bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func(log utils.Logger, developerMode bool) {
+				if x := recover(); x != nil {
+					stack := string(debug.Stack())
+
+					log.Errorw(
+						"Recovered from a panic in an HTTP handler",
+						"url", r.URL.String(),
+						"error", x,
+						"stack", string(debug.Stack()),
+					)
+
+					txt := "Paniced while handling the request. "
+
+					if developerMode {
+						txt += fmt.Sprintf("Error: %v. Stack: %v", x, stack)
+					} else {
+						txt += "Please check the server logs for more details."
+					}
+
+					http.Error(w, txt, http.StatusInternalServerError)
+				}
+			}(log, developerMode)
+
+			next.ServeHTTP(w, r)
+		})
 	}
 }
 


### PR DESCRIPTION
#### Summary
The plugin has two main entry points for external request: commands and HTTP requests. A panic in either the command or HTTP handler does shut down the whole plugin. While the plugin health check helps with mitigating the impact, a malicious attacker could continue to crash the plugin until the health check doesn't kick in any longer.

This PR fixes the attack vector by introducing a recovery handler for both command and HTTP requests. Debug information are logged. When the server is running in developer mode it also outputs the debug information in the command response and the HTTP response respectively. That should help developers with debugging without having to switch context.

#### Screenshots
![Screenshot from 2021-08-26 13-38-05](https://user-images.githubusercontent.com/16541325/130957079-105c97d4-ccc7-49ed-977f-f576143aad97.png)
![Screenshot from 2021-08-26 13-38-40](https://user-images.githubusercontent.com/16541325/130957087-7d544c47-ad18-40d2-9234-6dae49d56872.png)


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38155

