### PR TITLE
[MM-38244] User level subscriptions

### DIFF
--- a/apps/appclient/mattermost_client.go
+++ b/apps/appclient/mattermost_client.go
@@ -83,30 +83,30 @@ func (c *Client) KVDelete(id string, prefix string) error {
 	return nil
 }
 
-func (c *Client) Subscribe(sub *apps.Subscription) (*apps.SubscriptionResponse, error) {
-	subResponse, res, err := c.ClientPP.Subscribe(sub)
+func (c *Client) Subscribe(sub *apps.Subscription) error {
+	res, err := c.ClientPP.Subscribe(sub)
 	if res.StatusCode != http.StatusCreated && res.StatusCode != http.StatusOK {
 		if err != nil {
-			return nil, err
+			return err
 		}
 
-		return nil, errors.Errorf("returned with status %d", res.StatusCode)
+		return errors.Errorf("returned with status %d", res.StatusCode)
 	}
 
-	return subResponse, nil
+	return nil
 }
 
-func (c *Client) Unsubscribe(sub *apps.Subscription) (*apps.SubscriptionResponse, error) {
-	subResponse, res, err := c.ClientPP.Unsubscribe(sub)
+func (c *Client) Unsubscribe(sub *apps.Subscription) error {
+	res, err := c.ClientPP.Unsubscribe(sub)
 	if res.StatusCode != http.StatusCreated && res.StatusCode != http.StatusOK {
 		if err != nil {
-			return nil, err
+			return err
 		}
 
-		return nil, errors.Errorf("returned with status %d", res.StatusCode)
+		return errors.Errorf("returned with status %d", res.StatusCode)
 	}
 
-	return subResponse, nil
+	return nil
 }
 
 func (c *Client) StoreOAuth2App(appID apps.AppID, clientID, clientSecret string) error {

--- a/apps/appclient/mattermost_client_pp.go
+++ b/apps/appclient/mattermost_client_pp.go
@@ -99,34 +99,40 @@ func (c *ClientPP) KVDelete(id string, prefix string) (*model.Response, error) {
 	return model.BuildResponse(r), nil
 }
 
-func (c *ClientPP) Subscribe(request *apps.Subscription) (*apps.SubscriptionResponse, *model.Response, error) {
+func (c *ClientPP) Subscribe(request *apps.Subscription) (*model.Response, error) {
 	r, err := c.DoAPIPOST(c.apipath(appspath.Subscribe), request.ToJSON()) // nolint:bodyclose
 	if err != nil {
-		return nil, model.BuildResponse(r), err
+		return model.BuildResponse(r), err
 	}
 	defer c.closeBody(r)
 
-	subResponse, err := apps.SubscriptionResponseFromJSON(r.Body)
-	if err != nil {
-		return nil, model.BuildResponse(r), err
-	}
-
-	return subResponse, model.BuildResponse(r), nil
+	return model.BuildResponse(r), nil
 }
 
-func (c *ClientPP) Unsubscribe(request *apps.Subscription) (*apps.SubscriptionResponse, *model.Response, error) {
-	r, err := c.DoAPIPOST(c.apipath(appspath.Unsubscribe), request.ToJSON()) // nolint:bodyclose
+func (c *ClientPP) GetSubscriptions() ([]apps.Subscription, *model.Response, error) {
+	r, err := c.DoAPIGET(c.apipath(appspath.Subscribe), "") // nolint:bodyclose
 	if err != nil {
 		return nil, model.BuildResponse(r), err
 	}
 	defer c.closeBody(r)
 
-	subResponse, err := apps.SubscriptionResponseFromJSON(r.Body)
+	var subs []apps.Subscription
+	err = json.NewDecoder(r.Body).Decode(&subs)
 	if err != nil {
 		return nil, model.BuildResponse(r), err
 	}
 
-	return subResponse, model.BuildResponse(r), nil
+	return subs, model.BuildResponse(r), nil
+}
+
+func (c *ClientPP) Unsubscribe(request *apps.Subscription) (*model.Response, error) {
+	r, err := c.DoAPIPOST(c.apipath(appspath.Unsubscribe), request.ToJSON()) // nolint:bodyclose
+	if err != nil {
+		return model.BuildResponse(r), err
+	}
+	defer c.closeBody(r)
+
+	return model.BuildResponse(r), nil
 }
 
 func (c *ClientPP) StoreOAuth2App(appID apps.AppID, clientID, clientSecret string) (*model.Response, error) {

--- a/apps/call.go
+++ b/apps/call.go
@@ -192,9 +192,9 @@ func CallRequestFromJSONReader(in io.Reader) (*CallRequest, error) {
 	return &c, nil
 }
 
-func NewCall(url string) Call {
+func NewCall(path string) Call {
 	c := Call{
-		Path: url,
+		Path: path,
 	}
 	return c
 }

--- a/server/appservices/service.go
+++ b/server/appservices/service.go
@@ -20,9 +20,9 @@ var ErrIsABot = errors.New("is a bot")
 type Service interface {
 	// Subscriptions
 
-	Subscribe(actingUserID string, _ apps.Subscription) error
+	Subscribe(sub apps.Subscription) error
 	GetSubscriptions(actingUserID string) ([]apps.Subscription, error)
-	Unsubscribe(actingUserID string, _ apps.Subscription) error
+	Unsubscribe(sub apps.Subscription) error
 
 	// KV
 

--- a/server/httpin/restapi/e2e_subscribe_test.go
+++ b/server/httpin/restapi/e2e_subscribe_test.go
@@ -1,3 +1,4 @@
+//go:build e2e
 // +build e2e
 
 package restapi
@@ -10,6 +11,7 @@ import (
 	"github.com/mattermost/mattermost-plugin-apps/apps"
 	"github.com/mattermost/mattermost-plugin-apps/apps/appclient"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,24 +20,123 @@ func TestSubscribeE2E(t *testing.T) {
 	SetupPP(th, t)
 	defer th.TearDown()
 
-	t.Run("test Subscribe API", func(t *testing.T) {
+	t.Run("Unauthenticated requests are rejected", func(t *testing.T) {
 		subscription := &apps.Subscription{
 			AppID:     "test-apiId",
-			Subject:   "test-subject",
+			Subject:   apps.SubjectUserJoinedChannel,
 			ChannelID: th.ServerTestHelper.BasicChannel.Id,
 			TeamID:    th.ServerTestHelper.BasicTeam.Id,
+			Call: apps.Call{
+				Path: "/some/path",
+			},
+		}
+		client := th.CreateClientPP()
+
+		resp, err := client.Subscribe(subscription)
+		require.Error(t, err)
+		api4.CheckUnauthorizedStatus(t, resp)
+
+		subs, resp, err := client.GetSubscriptions()
+		require.Error(t, err)
+		api4.CheckUnauthorizedStatus(t, resp)
+		require.Nil(t, subs)
+
+		resp, err = client.Unsubscribe(subscription)
+		require.Error(t, err)
+		api4.CheckUnauthorizedStatus(t, resp)
+	})
+
+	t.Run("Users can delete there own subscriptions", func(t *testing.T) {
+		subscription := &apps.Subscription{
+			AppID:     "test-apiId",
+			Subject:   apps.SubjectUserJoinedChannel,
+			ChannelID: th.ServerTestHelper.BasicChannel.Id,
+			TeamID:    th.ServerTestHelper.BasicTeam.Id,
+			Call: apps.Call{
+				Path: "/some/path",
+			},
 		}
 
-		th.TestForSystemAdmin(t, func(t *testing.T, client *appclient.ClientPP) {
-			// subscribe
-			_, resp, err := client.Subscribe(subscription)
+		th.TestForUserAndSystemAdmin(t, func(t *testing.T, client *appclient.ClientPP) {
+			// Subscribe
+			resp, err := client.Subscribe(subscription)
 			require.NoError(t, err)
 			api4.CheckOKStatus(t, resp)
 
-			// unsubscribe
-			_, resp, err = client.Unsubscribe(subscription)
+			// List subscriptions
+			subs, resp, err := client.GetSubscriptions()
 			require.NoError(t, err)
 			api4.CheckOKStatus(t, resp)
+			assert.Len(t, subs, 1)
+
+			// Unsubscribe
+			resp, err = client.Unsubscribe(subscription)
+			require.NoError(t, err)
+			api4.CheckOKStatus(t, resp)
+
+			// List subscriptions
+			subs, resp, err = client.GetSubscriptions()
+			require.NoError(t, err)
+			api4.CheckOKStatus(t, resp)
+			assert.Len(t, subs, 0)
 		})
+	})
+
+	t.Run("Users can't delete other users subscriptions", func(t *testing.T) {
+		subscription := &apps.Subscription{
+			AppID:     "test-apiId",
+			Subject:   apps.SubjectUserJoinedChannel,
+			ChannelID: th.ServerTestHelper.BasicChannel.Id,
+			TeamID:    th.ServerTestHelper.BasicTeam.Id,
+			Call: apps.Call{
+				Path: "/some/path",
+			},
+		}
+		resp, err := th.SystemAdminClientPP.Subscribe(subscription)
+		require.NoError(t, err)
+		api4.CheckOKStatus(t, resp)
+
+		resp, err = th.ClientPP.Unsubscribe(subscription)
+		require.Error(t, err)
+		api4.CheckNotFoundStatus(t, resp)
+	})
+
+	t.Run("Users can't see other users subscriptions", func(t *testing.T) {
+		subscription := &apps.Subscription{
+			AppID:     "test-apiId",
+			Subject:   apps.SubjectUserJoinedChannel,
+			ChannelID: th.ServerTestHelper.BasicChannel.Id,
+			TeamID:    th.ServerTestHelper.BasicTeam.Id,
+			Call: apps.Call{
+				Path: "/some/path",
+			},
+		}
+		resp, err := th.SystemAdminClientPP.Subscribe(subscription)
+		require.NoError(t, err)
+		api4.CheckOKStatus(t, resp)
+
+		resp, err = th.ClientPP.Subscribe(subscription)
+		require.NoError(t, err)
+		api4.CheckOKStatus(t, resp)
+
+		subs, resp, err := th.ClientPP.GetSubscriptions()
+		require.NoError(t, err)
+		api4.CheckOKStatus(t, resp)
+		assert.Len(t, subs, 1)
+	})
+
+	t.Run("Bad request for missing subject", func(t *testing.T) {
+		subscription := &apps.Subscription{
+			AppID:     "test-apiId",
+			Subject:   "",
+			ChannelID: th.ServerTestHelper.BasicChannel.Id,
+			TeamID:    th.ServerTestHelper.BasicTeam.Id,
+			Call: apps.Call{
+				Path: "/some/path",
+			},
+		}
+		resp, err := th.SystemAdminClientPP.Subscribe(subscription)
+		require.Error(t, err)
+		api4.CheckBadRequestStatus(t, resp)
 	})
 }

--- a/server/httpin/restapi/restapitestlib.go
+++ b/server/httpin/restapi/restapitestlib.go
@@ -1,5 +1,6 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+//go:build e2e
 // +build e2e
 
 package restapi
@@ -53,6 +54,8 @@ func Setup(t testing.TB) *TestHelper {
 	th.ServerTestHelper = serverTestHelper
 
 	th.ClientPP = th.CreateClientPP()
+	th.ClientPP.AuthToken = th.ServerTestHelper.Client.AuthToken
+	th.ClientPP.AuthType = th.ServerTestHelper.Client.AuthType
 	th.SystemAdminClientPP = th.CreateClientPP()
 	th.SystemAdminClientPP.AuthToken = th.ServerTestHelper.SystemAdminClient.AuthToken
 	th.SystemAdminClientPP.AuthType = th.ServerTestHelper.SystemAdminClient.AuthType
@@ -124,6 +127,17 @@ func (th *TestHelper) CreateLocalClient(socketPath string) *appclient.ClientPP {
 	return client
 }
 
+func (th *TestHelper) TestForUser(t *testing.T, f func(*testing.T, *appclient.ClientPP), name ...string) {
+	var testName string
+	if len(name) > 0 {
+		testName = name[0] + "/"
+	}
+
+	t.Run(testName+"UserClientPP", func(t *testing.T) {
+		f(t, th.ClientPP)
+	})
+}
+
 func (th *TestHelper) TestForSystemAdmin(t *testing.T, f func(*testing.T, *appclient.ClientPP), name ...string) {
 	var testName string
 	if len(name) > 0 {
@@ -144,4 +158,9 @@ func (th *TestHelper) TestForLocal(t *testing.T, f func(*testing.T, *appclient.C
 	t.Run(testName+"LocalClientPP", func(t *testing.T) {
 		f(t, th.LocalClientPP)
 	})
+}
+
+func (th *TestHelper) TestForUserAndSystemAdmin(t *testing.T, f func(*testing.T, *appclient.ClientPP), name ...string) {
+	th.TestForUser(t, f)
+	th.TestForSystemAdmin(t, f)
 }

--- a/server/mocks/mock_appservices/mock_appservices.go
+++ b/server/mocks/mock_appservices/mock_appservices.go
@@ -135,29 +135,29 @@ func (mr *MockServiceMockRecorder) StoreOAuth2User(arg0, arg1, arg2 interface{})
 }
 
 // Subscribe mocks base method.
-func (m *MockService) Subscribe(arg0 string, arg1 apps.Subscription) error {
+func (m *MockService) Subscribe(arg0 apps.Subscription) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Subscribe", arg0, arg1)
+	ret := m.ctrl.Call(m, "Subscribe", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Subscribe indicates an expected call of Subscribe.
-func (mr *MockServiceMockRecorder) Subscribe(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockServiceMockRecorder) Subscribe(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MockService)(nil).Subscribe), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MockService)(nil).Subscribe), arg0)
 }
 
 // Unsubscribe mocks base method.
-func (m *MockService) Unsubscribe(arg0 string, arg1 apps.Subscription) error {
+func (m *MockService) Unsubscribe(arg0 apps.Subscription) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Unsubscribe", arg0, arg1)
+	ret := m.ctrl.Call(m, "Unsubscribe", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Unsubscribe indicates an expected call of Unsubscribe.
-func (mr *MockServiceMockRecorder) Unsubscribe(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockServiceMockRecorder) Unsubscribe(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unsubscribe", reflect.TypeOf((*MockService)(nil).Unsubscribe), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unsubscribe", reflect.TypeOf((*MockService)(nil).Unsubscribe), arg0)
 }

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -59,6 +59,7 @@ func TestOnActivate(t *testing.T) {
 
 	expectLog(testAPI, "LogDebug", 9)
 	expectLog(testAPI, "LogInfo", 5)
+	expectLog(testAPI, "LogError", 3)
 
 	testAPI.On("RegisterCommand", mock.AnythingOfType("*model.Command")).Return(nil)
 

--- a/server/proxy/notify_test.go
+++ b/server/proxy/notify_test.go
@@ -83,6 +83,7 @@ func TestNotifyMessageHasBeenPosted(t *testing.T) {
 				"sub.post_created.some_channel_id": {
 					{
 						AppID:     app1.AppID,
+						UserID:    "some_user_id",
 						Subject:   apps.SubjectPostCreated,
 						ChannelID: "some_channel_id",
 						Call:      apps.NewCall("/notify/post_created"),
@@ -96,6 +97,8 @@ func TestNotifyMessageHasBeenPosted(t *testing.T) {
 				post := &model.Post{
 					Message: message,
 				}
+				testAPI.On("HasPermissionToChannel", "some_user_id", "some_channel_id", model.PermissionReadChannel).Return(true)
+
 				err := p.NotifyMessageHasBeenPosted(post, apps.Context{
 					UserAgentContext: apps.UserAgentContext{
 						ChannelID: "some_channel_id",
@@ -110,14 +113,18 @@ func TestNotifyMessageHasBeenPosted(t *testing.T) {
 				"sub.post_created.some_channel_id": {},
 				"sub.bot_mentioned": {
 					{
-						AppID:   app1.AppID,
-						Subject: apps.SubjectBotMentioned,
-						Call:    apps.NewCall("/notify/bot_mention1"),
+						AppID:     app1.AppID,
+						UserID:    "some_user_id",
+						Subject:   apps.SubjectBotMentioned,
+						ChannelID: "some_channel_id",
+						Call:      apps.NewCall("/notify/bot_mention1"),
 					},
 					{
-						AppID:   app2.AppID,
-						Subject: apps.SubjectBotMentioned,
-						Call:    apps.NewCall("/notify/bot_mention2"),
+						AppID:     app2.AppID,
+						UserID:    "some_user_id",
+						Subject:   apps.SubjectBotMentioned,
+						ChannelID: "some_channel_id",
+						Call:      apps.NewCall("/notify/bot_mention2"),
 					},
 				},
 			},
@@ -128,7 +135,7 @@ func TestNotifyMessageHasBeenPosted(t *testing.T) {
 				post := &model.Post{
 					Message: message,
 				}
-				testAPI.On("HasPermissionToChannel", "bot2", "", model.PermissionReadChannel).Return(true)
+				testAPI.On("HasPermissionToChannel", "some_user_id", "some_channel_id", model.PermissionReadChannel).Return(true)
 				err := p.NotifyMessageHasBeenPosted(post, apps.Context{
 					UserAgentContext: apps.UserAgentContext{
 						ChannelID: "some_channel_id",
@@ -143,14 +150,18 @@ func TestNotifyMessageHasBeenPosted(t *testing.T) {
 				"sub.post_created.some_channel_id": {},
 				"sub.bot_mentioned": {
 					{
-						AppID:   app1.AppID,
-						Subject: apps.SubjectBotMentioned,
-						Call:    apps.NewCall("/notify/bot_mention1"),
+						AppID:     app1.AppID,
+						UserID:    "some_user_id",
+						Subject:   apps.SubjectBotMentioned,
+						ChannelID: "some_channel_id",
+						Call:      apps.NewCall("/notify/bot_mention1"),
 					},
 					{
-						AppID:   app2.AppID,
-						Subject: apps.SubjectBotMentioned,
-						Call:    apps.NewCall("/notify/bot_mention2"),
+						AppID:     app2.AppID,
+						UserID:    "some_user_id",
+						Subject:   apps.SubjectBotMentioned,
+						ChannelID: "some_channel_id",
+						Call:      apps.NewCall("/notify/bot_mention2"),
 					},
 				},
 			},
@@ -160,7 +171,7 @@ func TestNotifyMessageHasBeenPosted(t *testing.T) {
 					Message: message,
 				}
 
-				testAPI.On("HasPermissionToChannel", "bot2", "", model.PermissionReadChannel).Return(false)
+				testAPI.On("HasPermissionToChannel", "some_user_id", "some_channel_id", model.PermissionReadChannel).Return(false)
 
 				err := p.NotifyMessageHasBeenPosted(post, apps.Context{
 					UserAgentContext: apps.UserAgentContext{
@@ -199,15 +210,19 @@ func TestUserHasJoinedChannel(t *testing.T) {
 			subs: map[string][]apps.Subscription{
 				"sub.user_joined_channel.some_channel_id": {
 					{
-						AppID:   app1.AppID,
-						Subject: apps.SubjectUserJoinedChannel,
-						Call:    apps.NewCall("/notify/user_joined_channel"),
+						AppID:     app1.AppID,
+						UserID:    "some_user_id",
+						Subject:   apps.SubjectUserJoinedChannel,
+						ChannelID: "some_channel_id",
+						Call:      apps.NewCall("/notify/user_joined_channel"),
 					},
 				},
 				"sub.bot_joined_channel": {},
 			},
 			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
 				sendCallResponse(t, "/notify/user_joined_channel", apps.NewDataResponse(nil), up[app1.AppID])
+
+				testAPI.On("HasPermissionToChannel", "some_user_id", "some_channel_id", model.PermissionReadChannel).Return(true)
 
 				err := p.NotifyUserHasJoinedChannel(apps.Context{
 					UserAgentContext: apps.UserAgentContext{
@@ -223,19 +238,25 @@ func TestUserHasJoinedChannel(t *testing.T) {
 				"sub.user_joined_channel.some_channel_id": {},
 				"sub.bot_joined_channel": {
 					{
-						AppID:   app1.AppID,
-						Subject: apps.SubjectBotJoinedChannel,
-						Call:    apps.NewCall("/notify/bot_joined_channel1"),
+						AppID:     app1.AppID,
+						UserID:    "some_user_id",
+						Subject:   apps.SubjectBotJoinedChannel,
+						ChannelID: "some_channel_id",
+						Call:      apps.NewCall("/notify/bot_joined_channel1"),
 					},
 					{
-						AppID:   app2.AppID,
-						Subject: apps.SubjectBotJoinedChannel,
-						Call:    apps.NewCall("/notify/bot_joined_channel2"),
+						AppID:     app2.AppID,
+						UserID:    "some_user_id",
+						Subject:   apps.SubjectBotJoinedChannel,
+						ChannelID: "some_channel_id",
+						Call:      apps.NewCall("/notify/bot_joined_channel2"),
 					},
 				},
 			},
 			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
 				sendCallResponse(t, "/notify/bot_joined_channel1", apps.NewDataResponse(nil), up[app1.AppID])
+
+				testAPI.On("HasPermissionToChannel", "some_user_id", "some_channel_id", model.PermissionReadChannel).Return(true)
 
 				err := p.NotifyUserHasJoinedChannel(apps.Context{
 					UserID: app1.BotUserID,
@@ -273,15 +294,19 @@ func TestUserHasLeftChannel(t *testing.T) {
 			subs: map[string][]apps.Subscription{
 				"sub.user_left_channel.some_channel_id": {
 					{
-						AppID:   app1.AppID,
-						Subject: apps.SubjectUserLeftChannel,
-						Call:    apps.NewCall("/notify/user_left_channel"),
+						AppID:     app1.AppID,
+						UserID:    "some_user_id",
+						Subject:   apps.SubjectUserLeftChannel,
+						ChannelID: "some_channel_id",
+						Call:      apps.NewCall("/notify/user_left_channel"),
 					},
 				},
 				"sub.bot_left_channel": {},
 			},
 			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
 				sendCallResponse(t, "/notify/user_left_channel", apps.NewDataResponse(nil), up[app1.AppID])
+
+				testAPI.On("HasPermissionToChannel", "some_user_id", "some_channel_id", model.PermissionReadChannel).Return(true)
 
 				err := p.NotifyUserHasLeftChannel(apps.Context{
 					UserAgentContext: apps.UserAgentContext{
@@ -297,19 +322,25 @@ func TestUserHasLeftChannel(t *testing.T) {
 				"sub.user_left_channel.some_channel_id": {},
 				"sub.bot_left_channel": {
 					{
-						AppID:   app1.AppID,
-						Subject: apps.SubjectBotLeftChannel,
-						Call:    apps.NewCall("/notify/bot_left_channel1"),
+						AppID:     app1.AppID,
+						UserID:    "some_user_id",
+						Subject:   apps.SubjectBotLeftChannel,
+						ChannelID: "some_channel_id",
+						Call:      apps.NewCall("/notify/bot_left_channel1"),
 					},
 					{
-						AppID:   app2.AppID,
-						Subject: apps.SubjectBotLeftChannel,
-						Call:    apps.NewCall("/notify/bot_left_channel2"),
+						AppID:     app2.AppID,
+						UserID:    "some_user_id",
+						Subject:   apps.SubjectBotLeftChannel,
+						ChannelID: "some_channel_id",
+						Call:      apps.NewCall("/notify/bot_left_channel2"),
 					},
 				},
 			},
 			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
 				sendCallResponse(t, "/notify/bot_left_channel1", apps.NewDataResponse(nil), up[app1.AppID])
+
+				testAPI.On("HasPermissionToChannel", "some_user_id", "some_channel_id", model.PermissionReadChannel).Return(true)
 
 				err := p.NotifyUserHasLeftChannel(apps.Context{
 					UserID: app1.BotUserID,
@@ -348,7 +379,9 @@ func TestUserHasJoinedTeam(t *testing.T) {
 				"sub.user_joined_team.some_team_id": {
 					{
 						AppID:   app1.AppID,
+						UserID:  "some_user_id",
 						Subject: apps.SubjectUserJoinedTeam,
+						TeamID:  "some_team_id",
 						Call:    apps.NewCall("/notify/user_joined_team"),
 					},
 				},
@@ -356,6 +389,8 @@ func TestUserHasJoinedTeam(t *testing.T) {
 			},
 			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
 				sendCallResponse(t, "/notify/user_joined_team", apps.NewDataResponse(nil), up[app1.AppID])
+
+				testAPI.On("HasPermissionToTeam", "some_user_id", "some_team_id", model.PermissionViewTeam).Return(true)
 
 				err := p.NotifyUserHasJoinedTeam(apps.Context{
 					UserAgentContext: apps.UserAgentContext{
@@ -372,18 +407,24 @@ func TestUserHasJoinedTeam(t *testing.T) {
 				"sub.bot_joined_team": {
 					{
 						AppID:   app1.AppID,
-						Subject: apps.SubjectBotJoinedTeam,
+						UserID:  "some_user_id",
+						Subject: apps.SubjectUserJoinedTeam,
+						TeamID:  "some_team_id",
 						Call:    apps.NewCall("/notify/bot_joined_team1"),
 					},
 					{
 						AppID:   app2.AppID,
-						Subject: apps.SubjectBotJoinedTeam,
+						UserID:  "some_user_id",
+						Subject: apps.SubjectUserJoinedTeam,
+						TeamID:  "some_team_id",
 						Call:    apps.NewCall("/notify/bot_joined_team2"),
 					},
 				},
 			},
 			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
 				sendCallResponse(t, "/notify/bot_joined_team1", apps.NewDataResponse(nil), up[app1.AppID])
+
+				testAPI.On("HasPermissionToTeam", "some_user_id", "some_team_id", model.PermissionViewTeam).Return(true)
 
 				err := p.NotifyUserHasJoinedTeam(apps.Context{
 					UserID: app1.BotUserID,
@@ -422,7 +463,9 @@ func TestUserHasLeftTeam(t *testing.T) {
 				"sub.user_left_team.some_team_id": {
 					{
 						AppID:   app1.AppID,
-						Subject: apps.SubjectUserLeftChannel,
+						UserID:  "some_user_id",
+						Subject: apps.SubjectUserLeftTeam,
+						TeamID:  "some_team_id",
 						Call:    apps.NewCall("/notify/user_left_team"),
 					},
 				},
@@ -430,6 +473,8 @@ func TestUserHasLeftTeam(t *testing.T) {
 			},
 			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
 				sendCallResponse(t, "/notify/user_left_team", apps.NewDataResponse(nil), up[app1.AppID])
+
+				testAPI.On("HasPermissionToTeam", "some_user_id", "some_team_id", model.PermissionViewTeam).Return(true)
 
 				err := p.NotifyUserHasLeftTeam(apps.Context{
 					UserAgentContext: apps.UserAgentContext{
@@ -446,18 +491,24 @@ func TestUserHasLeftTeam(t *testing.T) {
 				"sub.bot_left_team": {
 					{
 						AppID:   app1.AppID,
+						UserID:  "some_user_id",
 						Subject: apps.SubjectBotLeftTeam,
+						TeamID:  "some_team_id",
 						Call:    apps.NewCall("/notify/bot_left_team1"),
 					},
 					{
 						AppID:   app2.AppID,
+						UserID:  "some_user_id",
 						Subject: apps.SubjectBotLeftTeam,
+						TeamID:  "some_team_id",
 						Call:    apps.NewCall("/notify/bot_left_team2"),
 					},
 				},
 			},
 			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
 				sendCallResponse(t, "/notify/bot_left_team1", apps.NewDataResponse(nil), up[app1.AppID])
+
+				testAPI.On("HasPermissionToTeam", "some_user_id", "some_team_id", model.PermissionViewTeam).Return(true)
 
 				err := p.NotifyUserHasLeftTeam(apps.Context{
 					UserID: app1.BotUserID,
@@ -481,13 +532,17 @@ func TestChannelHasBeenCreated(t *testing.T) {
 				"sub.channel_created.some_team_id": {
 					{
 						AppID:   app1.AppID,
+						UserID:  "some_user_id",
 						Subject: apps.SubjectChannelCreated,
+						TeamID:  "some_team_id",
 						Call:    apps.NewCall("/notify/channel_created"),
 					},
 				},
 			},
 			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
 				sendCallResponse(t, "/notify/channel_created", apps.NewDataResponse(nil), up[app1.AppID])
+
+				testAPI.On("HasPermissionToTeam", "some_user_id", "some_team_id", model.PermissionListTeamChannels).Return(true)
 
 				err := p.Notify(
 					apps.Context{
@@ -513,6 +568,7 @@ func TestUserHasBeenCreated(t *testing.T) {
 				"sub.user_created": {
 					{
 						AppID:   app1.AppID,
+						UserID:  "some_user_id",
 						Subject: apps.SubjectUserCreated,
 						Call:    apps.NewCall("/notify/user_created"),
 					},
@@ -520,6 +576,8 @@ func TestUserHasBeenCreated(t *testing.T) {
 			},
 			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
 				sendCallResponse(t, "/notify/user_created", apps.NewDataResponse(nil), up[app1.AppID])
+
+				testAPI.On("HasPermissionTo", "some_user_id", model.PermissionViewMembers).Return(true)
 
 				err := p.Notify(
 					apps.Context{
@@ -578,6 +636,11 @@ func runNotifyTest(t *testing.T, allApps []apps.App, tc notifyTestcase) {
 	}
 
 	for name, subs := range tc.subs {
+		for _, sub := range subs {
+			err = sub.Validate()
+			require.NoError(t, err)
+		}
+
 		b, err := json.Marshal(subs)
 		require.NoError(t, err)
 		testAPI.On("KVGet", name).Return(b, nil)

--- a/utils/httputils/utils.go
+++ b/utils/httputils/utils.go
@@ -53,17 +53,22 @@ func WriteError(w http.ResponseWriter, err error) {
 		http.Error(w, "invalid (unknown?) error", http.StatusInternalServerError)
 		return
 	}
+
+	http.Error(w, err.Error(), ErrorToStatus(err))
+}
+
+func ErrorToStatus(err error) int {
 	switch errors.Cause(err) {
 	case utils.ErrForbidden:
-		http.Error(w, err.Error(), http.StatusForbidden)
+		return http.StatusForbidden
 	case utils.ErrUnauthorized:
-		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return http.StatusUnauthorized
 	case utils.ErrNotFound:
-		http.Error(w, err.Error(), http.StatusNotFound)
+		return http.StatusNotFound
 	case utils.ErrInvalid:
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		return http.StatusBadRequest
 	default:
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return http.StatusInternalServerError
 	}
 }
 


### PR DESCRIPTION
#### Summary
This PR adds support for user level subscriptions. All subscriptions are now scoped per user removing the need for an admin check. On subscribing and on every invocation the permission to the resource are checked.

I've considered using the REST API for checking, but the invocations lack a user token.

#### TODO
- [ ] Add more cases to `Validate`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-33768
https://mattermost.atlassian.net/browse/MM-38244
https://mattermost.atlassian.net/browse/MM-33767