### PR TITLE
MM-39776 moved Build variables to config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,9 @@ GO_VERSION_VALIDATION_ERR_MSG = Golang version is not supported, please update t
 BUILD_DATE = $(shell date -u)
 BUILD_HASH = $(shell git rev-parse HEAD)
 BUILD_HASH_SHORT = $(shell git rev-parse --short HEAD)
-LDFLAGS += -X "github.com/mattermost/mattermost-plugin-apps/server.BuildDate=$(BUILD_DATE)"
-LDFLAGS += -X "github.com/mattermost/mattermost-plugin-apps/server.BuildHash=$(BUILD_HASH)"
-LDFLAGS += -X "github.com/mattermost/mattermost-plugin-apps/server.BuildHashShort=$(BUILD_HASH_SHORT)"
+LDFLAGS += -X "github.com/mattermost/mattermost-plugin-apps/server/config.BuildDate=$(BUILD_DATE)"
+LDFLAGS += -X "github.com/mattermost/mattermost-plugin-apps/server/config.BuildHash=$(BUILD_HASH)"
+LDFLAGS += -X "github.com/mattermost/mattermost-plugin-apps/server/config.BuildHashShort=$(BUILD_HASH_SHORT)"
 GO_BUILD_FLAGS += -ldflags '$(LDFLAGS)'
 GO_TEST_FLAGS += -ldflags '$(LDFLAGS)'
 

--- a/build/custom.mk
+++ b/build/custom.mk
@@ -3,7 +3,7 @@ ifndef MM_RUDDER_WRITE_KEY
     MM_RUDDER_WRITE_KEY = 1d5bMvdrfWClLxgK1FvV3s4U1tg
 endif
 
-GO_BUILD_FLAGS += -ldflags '-X "github.com/mattermost/mattermost-plugin-api/experimental/telemetry.rudderWriteKey=$(MM_RUDDER_WRITE_KEY)"'
+LDFLAGS += -X "github.com/mattermost/mattermost-plugin-api/experimental/telemetry.rudderWriteKey=$(MM_RUDDER_WRITE_KEY)"
 
 default: all
 

--- a/server/builtin/app.go
+++ b/server/builtin/app.go
@@ -95,7 +95,7 @@ func NewBuiltinApp(conf config.Service, proxy proxy.Service, httpOut httpout.Ser
 func Manifest(conf config.Config) apps.Manifest {
 	return apps.Manifest{
 		AppID:       AppID,
-		Version:     apps.AppVersion(conf.BuildConfig.BuildHashShort),
+		Version:     apps.AppVersion(conf.PluginManifest.Version + "-" + conf.BuildHashShort),
 		DisplayName: AppDisplayName,
 		Description: AppDescription,
 		Bindings: &apps.Call{

--- a/server/builtin/app.go
+++ b/server/builtin/app.go
@@ -95,7 +95,7 @@ func NewBuiltinApp(conf config.Service, proxy proxy.Service, httpOut httpout.Ser
 func Manifest(conf config.Config) apps.Manifest {
 	return apps.Manifest{
 		AppID:       AppID,
-		Version:     apps.AppVersion(conf.PluginManifest.Version + "-" + conf.BuildHashShort),
+		Version:     apps.AppVersion(conf.PluginManifest.Version),
 		DisplayName: AppDisplayName,
 		Description: AppDescription,
 		Bindings: &apps.Call{

--- a/server/builtin/info.go
+++ b/server/builtin/info.go
@@ -45,7 +45,7 @@ func (a *builtinApp) info() handler {
 					Other: "Mattermost Apps plugin version: {{.Version}}, {{.URL}}, built {{.BuildDate}}, Cloud Mode: {{.CloudMode}}, Developer Mode: {{.DeveloperMode}}",
 				},
 				TemplateData: map[string]string{
-					"Version":       conf.Version,
+					"Version":       conf.PluginManifest.Version,
 					"URL":           fmt.Sprintf("[%s](https://github.com/mattermost/%s/commit/%s)", conf.BuildHashShort, config.Repository, conf.BuildHash),
 					"BuildDate":     conf.BuildDate,
 					"CloudMode":     fmt.Sprintf("%t", conf.MattermostCloudMode),

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -39,12 +39,9 @@ type StoredConfig struct {
 	LocalManifests map[string]string `json:"local_manifests,omitempty"`
 }
 
-type BuildConfig struct {
-	model.Manifest
-	BuildDate      string
-	BuildHash      string
-	BuildHashShort string
-}
+var BuildDate string
+var BuildHash string
+var BuildHashShort string
 
 // Config represents the the metadata handed to all request runners (command,
 // http).
@@ -52,7 +49,11 @@ type BuildConfig struct {
 // Config should be abbreviated as `conf`.
 type Config struct {
 	StoredConfig
-	BuildConfig
+
+	PluginManifest model.Manifest
+	BuildDate      string
+	BuildHash      string
+	BuildHashShort string
 
 	DeveloperMode       bool
 	MattermostCloudMode bool
@@ -119,7 +120,7 @@ func (conf *Config) Update(stored StoredConfig, mmconf *model.Config, license *m
 	conf.MattermostSiteURL = *mattermostSiteURL
 	conf.MattermostSiteHostname = mattermostURL.Hostname()
 	conf.MattermostLocalURL = localURL
-	conf.PluginURLPath = "/plugins/" + conf.BuildConfig.Manifest.Id
+	conf.PluginURLPath = "/plugins/" + conf.PluginManifest.Id
 	conf.PluginURL = strings.TrimRight(*mattermostSiteURL, "/") + conf.PluginURLPath
 
 	conf.MaxWebhookSize = 75 * 1024 * 1024 // 75Mb
@@ -166,6 +167,6 @@ func (conf *Config) Update(stored StoredConfig, mmconf *model.Config, license *m
 
 func (conf Config) GetPluginVersionInfo() map[string]interface{} {
 	return map[string]interface{}{
-		"version": conf.Manifest.Version,
+		"version": conf.PluginManifest.Version,
 	}
 }

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -1,4 +1,4 @@
-package main
+package config
 
 import (
 	"testing"
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMain(t *testing.T) {
+func TestBuildConfig(t *testing.T) {
 	assert.NotEmpty(t, BuildDate)
 	assert.NotEmpty(t, BuildHash)
 	assert.NotEmpty(t, BuildHashShort)

--- a/server/config/service.go
+++ b/server/config/service.go
@@ -50,7 +50,6 @@ type service struct {
 }
 
 func NewService(mm *pluginapi.Client, pliginManifest model.Manifest, botUserID string, telemetry *telemetry.Telemetry, i18nBundle *i18n.Bundle) Service {
-	// utils.NewPluginLogger(mm).Debugf("<>/<> NewService 1 %q", BuildHash)
 	return &service{
 		pluginManifest: pliginManifest,
 		botUserID:      botUserID,
@@ -129,7 +128,6 @@ func (s *service) reloadMattermostConfig() *model.Config {
 func (s *service) Reconfigure(stored StoredConfig, services ...Configurable) error {
 	mmconf := s.reloadMattermostConfig()
 	newConfig := s.Get()
-	s.log.Debugf("<>/<> 0 %q %q", BuildHash, newConfig.BuildHash)
 
 	// GetLicense silently drops an RPC error
 	// (https://github.com/mattermost/mattermost-server/blob/fc75b72bbabf7fabfad24b9e1e4c321ca9b9b7f1/plugin/client_rpc_generated.go#L864).
@@ -142,12 +140,10 @@ func (s *service) Reconfigure(stored StoredConfig, services ...Configurable) err
 		}
 	}
 
-	s.log.Debugf("<>/<> 1 %q %q", BuildHash, newConfig.BuildHash)
 	err := newConfig.Update(stored, mmconf, license, s.log)
 	if err != nil {
 		return err
 	}
-	s.log.Debugf("<>/<> 2 %q %q", BuildHash, newConfig.BuildHash)
 
 	s.lock.Lock()
 	s.conf = &newConfig
@@ -160,7 +156,6 @@ func (s *service) Reconfigure(stored StoredConfig, services ...Configurable) err
 		}
 	}
 
-	s.log.Debugf("<>/<> 3 %q %q", BuildHash, newConfig.BuildHash)
 	return nil
 }
 

--- a/server/main.go
+++ b/server/main.go
@@ -2,21 +2,8 @@ package main
 
 import (
 	"github.com/mattermost/mattermost-server/v6/plugin"
-
-	"github.com/mattermost/mattermost-plugin-apps/server/config"
 )
 
-var BuildDate string
-var BuildHash string
-var BuildHashShort string
-
 func main() {
-	plugin.ClientMain(
-		NewPlugin(
-			config.BuildConfig{
-				Manifest:       manifest,
-				BuildHash:      BuildHash,
-				BuildHashShort: BuildHashShort,
-				BuildDate:      BuildDate,
-			}))
+	plugin.ClientMain(NewPlugin(manifest))
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -33,7 +33,7 @@ import (
 
 type Plugin struct {
 	plugin.MattermostPlugin
-	config.BuildConfig
+	manifest model.Manifest
 
 	conf config.Service
 	log  utils.Logger
@@ -49,9 +49,9 @@ type Plugin struct {
 	tracker         *telemetry.Telemetry
 }
 
-func NewPlugin(buildConfig config.BuildConfig) *Plugin {
+func NewPlugin(pluginManifest model.Manifest) *Plugin {
 	return &Plugin{
-		BuildConfig: buildConfig,
+		manifest: pluginManifest,
 	}
 }
 
@@ -80,7 +80,7 @@ func (p *Plugin) OnActivate() (err error) {
 
 	p.tracker = telemetry.NewTelemetry(nil)
 
-	p.conf = config.NewService(mm, p.BuildConfig, botUserID, p.tracker, i18nBundle)
+	p.conf = config.NewService(mm, p.manifest, botUserID, p.tracker, i18nBundle)
 	stored := config.StoredConfig{}
 	_ = mm.Configuration.LoadPluginConfiguration(&stored)
 	err = p.conf.Reconfigure(stored)

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -16,15 +16,7 @@ import (
 
 func TestOnActivate(t *testing.T) {
 	testAPI := &plugintest.API{}
-	p := NewPlugin(
-		config.BuildConfig{
-			Manifest:       manifest,
-			BuildHash:      BuildHash,
-			BuildHashShort: BuildHashShort,
-			BuildDate:      BuildDate,
-		},
-	)
-
+	p := NewPlugin(manifest)
 	p.API = testAPI
 
 	testAPI.On("GetServerVersion").Return("5.30.1")
@@ -73,14 +65,7 @@ func TestOnActivate(t *testing.T) {
 
 func TestOnDeactivate(t *testing.T) {
 	testAPI := &plugintest.API{}
-	p := NewPlugin(
-		config.BuildConfig{
-			Manifest:       manifest,
-			BuildHash:      BuildHash,
-			BuildHashShort: BuildHashShort,
-			BuildDate:      BuildDate,
-		},
-	)
+	p := NewPlugin(manifest)
 
 	p.API = testAPI
 
@@ -88,7 +73,7 @@ func TestOnDeactivate(t *testing.T) {
 	i18nBundle, _ := i18n.InitBundle(testAPI, filepath.Join("assets", "i18n"))
 
 	mm := pluginapi.NewClient(p.API, p.Driver)
-	p.conf = config.NewService(mm, p.BuildConfig, "the_bot_id", nil, i18nBundle)
+	p.conf = config.NewService(mm, manifest, "the_bot_id", nil, i18nBundle)
 
 	testAPI.On("PublishWebSocketEvent", "plugin_disabled", map[string]interface{}{"version": manifest.Version}, &model.WebsocketBroadcast{})
 

--- a/server/store/apps.go
+++ b/server/store/apps.go
@@ -143,7 +143,7 @@ func (s *appStore) Save(app apps.App) error {
 	conf, mm, log := s.conf.Basic()
 	prevSHA := conf.InstalledApps[string(app.AppID)]
 
-	app.Manifest.SchemaVersion = conf.BuildConfig.Version
+	app.Manifest.SchemaVersion = conf.PluginManifest.Version
 
 	data, err := json.Marshal(app)
 	if err != nil {

--- a/server/store/manifest.go
+++ b/server/store/manifest.go
@@ -216,7 +216,7 @@ func (s *manifestStore) StoreLocal(m apps.Manifest) error {
 	conf, mm, log := s.conf.Basic()
 	prevSHA := conf.LocalManifests[string(m.AppID)]
 
-	m.SchemaVersion = conf.BuildConfig.Version
+	m.SchemaVersion = conf.PluginManifest.Version
 
 	data, err := json.Marshal(m)
 	if err != nil {


### PR DESCRIPTION
#### Summary
The build hashes were no longer displayed in `/apps info`. 2 causes were identified and fixed.
- package path seems to be different when building as a test and deploy, the latter does not work with `.../server`. Moved the build variables to `.../server/config` which is a FQ, accurate package name and it works in both cases
- https://stackoverflow.com/questions/44148449/how-to-check-whether-golang-binary-is-compiled-with-ldflags-s-w/44168916 - `custom.mk` was adding a separate `-ldflags`, overriding the prior values. Fixed by changing `LDFLAGS` instead of `GO_BUILD_FLAGS`

#### Ticket:
https://mattermost.atlassian.net/browse/MM-39776