### PR TITLE
[MM-39827] Remove AdminAccessToken & PermissionActAsAdmin

### DIFF
--- a/apps/appclient/mattermost_client.go
+++ b/apps/appclient/mattermost_client.go
@@ -28,10 +28,6 @@ func AsActingUser(cc apps.Context) *Client {
 	return as(cc.ActingUserID, cc.ActingUserAccessToken, cc)
 }
 
-func AsAdmin(cc apps.Context) *Client {
-	return as(cc.ActingUserID, cc.AdminAccessToken, cc)
-}
-
 func NewClient(userID, token, mattermostSiteURL string) *Client {
 	c := Client{
 		userID:   userID,

--- a/apps/context.go
+++ b/apps/context.go
@@ -73,7 +73,6 @@ type ExpandedContext struct {
 
 	ActingUser            *model.User    `json:"acting_user,omitempty"`
 	ActingUserAccessToken string         `json:"acting_user_access_token,omitempty"`
-	AdminAccessToken      string         `json:"admin_access_token,omitempty"`
 	OAuth2                OAuth2Context  `json:"oauth2,omitempty"`
 	App                   *App           `json:"app,omitempty"`
 	Channel               *model.Channel `json:"channel,omitempty"`

--- a/apps/expand.go
+++ b/apps/expand.go
@@ -44,13 +44,6 @@ type Expand struct {
 	// https://mattermost.atlassian.net/browse/MM-31117
 	ActingUserAccessToken ExpandLevel `json:"acting_user_access_token,omitempty"`
 
-	// AdminAccessToken: all. Include admin-level access token in the request.
-	// Requires act_as_admin permission to have been granted to the app. This
-	// should be a special Mattermost OAuth2 token, but until it's implemented
-	// the MM session token is used.
-	// https://mattermost.atlassian.net/browse/MM-28542
-	AdminAccessToken ExpandLevel `json:"admin_access_token,omitempty"`
-
 	// Channel: all for model.Channel, summary for Id, DeleteAt, TeamId, Type,
 	// DisplayName, Name
 	Channel ExpandLevel `json:"channel,omitempty"`

--- a/apps/permissions.go
+++ b/apps/permissions.go
@@ -26,10 +26,6 @@ const (
 	// OAuth2 accounts, and then use user API tokens.
 	PermissionActAsUser Permission = "act_as_user"
 
-	// PermissionActAsAdmin means that the app is allowed to request admin-level
-	// access tokens in its calls.
-	PermissionActAsAdmin Permission = "act_as_admin"
-
 	// PermissionRemoteOAuth2 means that the app is allowed to use remote (3rd
 	// party) OAuth2 support, and will store secrets to 3rd party system(s).
 	PermissionRemoteOAuth2 Permission = "remote_oauth2"
@@ -53,8 +49,6 @@ func (p Permission) String() string {
 	switch p {
 	case PermissionUserJoinedChannelNotification:
 		m = "be notified when users join channels"
-	case PermissionActAsAdmin:
-		m = "use Mattermost REST API as a sysadmin"
 	case PermissionActAsUser:
 		m = "use Mattermost REST API as connected users"
 	case PermissionActAsBot:

--- a/examples/go/hello-webhooks/hello.go
+++ b/examples/go/hello-webhooks/hello.go
@@ -76,7 +76,7 @@ func install(w http.ResponseWriter, req *http.Request) {
 	channelID := creq.Context.ChannelID
 
 	// Add the Bot user to the team and the channel.
-	asAdmin := appclient.AsAdmin(creq.Context)
+	asAdmin := appclient.AsActingUser(creq.Context)
 	asAdmin.AddTeamMember(teamID, creq.Context.BotUserID)
 	asAdmin.AddChannelMember(channelID, creq.Context.BotUserID)
 

--- a/examples/go/hello-webhooks/manifest.json
+++ b/examples/go/hello-webhooks/manifest.json
@@ -6,7 +6,7 @@
 	"icon": "icon.png",
 	"homepage_url": "https://github.com/mattermost/mattermost-plugin-apps/examples/go/hello-webhooks",
 	"requested_permissions": [
-		"act_as_admin",
+		"act_as_user",
 		"act_as_bot",
 		"remote_webhooks"
 	],
@@ -16,7 +16,7 @@
 	"on_install": {
 		"path": "/install",
 		"expand": {
-			"admin_access_token": "all"
+			"user_access_token": "all"
 		}
 	},
 	"http": {

--- a/server/builtin/app.go
+++ b/server/builtin/app.go
@@ -142,9 +142,7 @@ func App(conf config.Config) apps.App {
 		GrantedLocations: apps.Locations{
 			apps.LocationCommand,
 		},
-		GrantedPermissions: apps.Permissions{
-			apps.PermissionActAsAdmin,
-		},
+		GrantedPermissions: apps.Permissions{},
 	}
 }
 

--- a/server/builtin/app.go
+++ b/server/builtin/app.go
@@ -142,7 +142,9 @@ func App(conf config.Config) apps.App {
 		GrantedLocations: apps.Locations{
 			apps.LocationCommand,
 		},
-		GrantedPermissions: apps.Permissions{},
+		GrantedPermissions: apps.Permissions{
+			apps.PermissionActAsUser,
+		},
 	}
 }
 

--- a/server/builtin/debug_bindings.go
+++ b/server/builtin/debug_bindings.go
@@ -13,8 +13,7 @@ import (
 var debugBindingsCall = apps.Call{
 	Path: pDebugBindings,
 	Expand: &apps.Expand{
-		ActingUser:       apps.ExpandSummary,
-		AdminAccessToken: apps.ExpandAll,
+		ActingUser: apps.ExpandSummary,
 	},
 }
 

--- a/server/builtin/debug_bindings.go
+++ b/server/builtin/debug_bindings.go
@@ -65,7 +65,6 @@ func (a *builtinApp) debugBindings() handler {
 				bindings = a.proxy.GetAppBindings(proxy.NewIncomingFromContext(creq.Context), creq.Context, *app)
 			}
 			return apps.NewTextResponse(utils.JSONBlock(bindings))
-
 		},
 	}
 }

--- a/server/builtin/debug_clean.go
+++ b/server/builtin/debug_clean.go
@@ -28,8 +28,7 @@ func (a *builtinApp) debugClean() handler {
 				Call: &apps.Call{
 					Path: pDebugClean,
 					Expand: &apps.Expand{
-						AdminAccessToken: apps.ExpandAll, 
-						Locale:           apps.ExpandAll,
+						Locale: apps.ExpandAll,
 					},
 				},
 				Form: &noParameters,

--- a/server/builtin/install_consent.go
+++ b/server/builtin/install_consent.go
@@ -197,8 +197,7 @@ func (a *builtinApp) newInstallConsentForm(m apps.Manifest, creq apps.CallReques
 		Call: &apps.Call{
 			Path: pInstallConsent,
 			Expand: &apps.Expand{
-				AdminAccessToken: apps.ExpandAll,
-				ActingUser:       apps.ExpandSummary,
+				ActingUser: apps.ExpandSummary,
 			},
 			State: m.AppID,
 		},

--- a/server/httpin/restapi/call_test.go
+++ b/server/httpin/restapi/call_test.go
@@ -270,7 +270,6 @@ func TestCleanUserAgentContextIgnoredValues(t *testing.T) {
 			BotAccessToken:        "ignored_bot_access_token",
 			ActingUser:            &model.User{},
 			ActingUserAccessToken: "ignored_user_access_token",
-			AdminAccessToken:      "ignored_admin_access_token",
 			OAuth2:                apps.OAuth2Context{},
 			App:                   &apps.App{},
 			Channel:               &model.Channel{},

--- a/server/proxy/enable.go
+++ b/server/proxy/enable.go
@@ -21,7 +21,7 @@ func (p *Proxy) EnableApp(in Incoming, cc apps.Context, appID apps.AppID) (strin
 		return fmt.Sprintf("%s is already enabled", app.DisplayName), nil
 	}
 
-	asAdmin, err := p.getAdminClient(in)
+	asAdmin, err := p.getClient(in)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get an admin HTTP client")
 	}
@@ -81,7 +81,7 @@ func (p *Proxy) DisableApp(in Incoming, cc apps.Context, appID apps.AppID) (stri
 		message = fmt.Sprintf("Disabled %s", app.DisplayName)
 	}
 
-	asAdmin, err := p.getAdminClient(in)
+	asAdmin, err := p.getClient(in)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get an admin HTTP client")
 	}

--- a/server/proxy/incoming.go
+++ b/server/proxy/incoming.go
@@ -20,7 +20,6 @@ type Incoming struct {
 	PluginID              string
 	ActingUserID          string
 	ActingUserAccessToken string
-	AdminAccessToken      string
 	SessionID             string
 	SysAdminChecked       bool
 }
@@ -29,7 +28,6 @@ func NewIncomingFromContext(cc apps.Context) Incoming {
 	return Incoming{
 		ActingUserID:          cc.ActingUserID,
 		ActingUserAccessToken: cc.ActingUserAccessToken,
-		AdminAccessToken:      cc.AdminAccessToken,
 	}
 }
 
@@ -90,7 +88,6 @@ func (in Incoming) updateContext(cc apps.Context) apps.Context {
 	updated.ActingUserID = in.ActingUserID
 	updated.ExpandedContext = apps.ExpandedContext{
 		ActingUserAccessToken: in.ActingUserAccessToken,
-		AdminAccessToken:      in.AdminAccessToken,
 	}
 	return updated
 }
@@ -110,23 +107,13 @@ func (in *Incoming) ensureUserToken(mm *pluginapi.Client) error {
 	return nil
 }
 
-func (p *Proxy) getAdminClient(in Incoming) (mmclient.Client, error) {
+func (p *Proxy) getClient(in Incoming) (mmclient.Client, error) {
 	conf, mm, _ := p.conf.Basic()
 
-	if in.AdminAccessToken == "" {
-		if !in.SysAdminChecked {
-			err := utils.EnsureSysAdmin(mm, in.ActingUserID)
-			if err != nil {
-				return nil, errors.Wrap(err, "failed to get admin access to Mattermost")
-			}
-		}
-		err := in.ensureUserToken(mm)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to use the current user's token for admin access to Mattermost")
-		}
-		in.AdminAccessToken = in.ActingUserAccessToken
+	err := in.ensureUserToken(mm)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to use the current user's token for admin access to Mattermost")
 	}
 
-	asAdmin := mmclient.NewHTTPClient(conf, in.AdminAccessToken)
-	return asAdmin, nil
+	return mmclient.NewHTTPClient(conf, in.ActingUserAccessToken), nil
 }

--- a/server/proxy/install.go
+++ b/server/proxy/install.go
@@ -83,7 +83,7 @@ func (p *Proxy) InstallApp(in Incoming, cc apps.Context, appID apps.AppID, deplo
 		return nil, "", errors.Wrapf(err, "failed to install, %s path is not accessible", apps.DefaultPing.Path)
 	}
 
-	asAdmin, err := p.getAdminClient(in)
+	asAdmin, err := p.getClient(in)
 	if err != nil {
 		return nil, "", errors.Wrap(err, "failed to get an admin HTTP client")
 	}

--- a/server/proxy/uninstall.go
+++ b/server/proxy/uninstall.go
@@ -33,7 +33,7 @@ func (p *Proxy) UninstallApp(in Incoming, cc apps.Context, appID apps.AppID) (st
 		message = fmt.Sprintf("Uninstalled %s", app.DisplayName)
 	}
 
-	asAdmin, err := p.getAdminClient(in)
+	asAdmin, err := p.getClient(in)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get an admin HTTP client")
 	}


### PR DESCRIPTION
#### Summary
As discussed offline, the `AdminAccessToken` has no clear use case and caused confusion.  This  PR removes it alongside the  `PermissionActAsAdmin`.

This PR targets https://github.com/mattermost/mattermost-plugin-apps/pull/278 to avoid merge conflicts. It should be merged after https://github.com/mattermost/mattermost-plugin-apps/pull/278.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39827

### Breaking Changes
- Removed `AdminAccessToken` from `Expand`
- Removed `AdminAccessToken` from `Call.Context`
- Removed `PermissionActAsAdmin` permission

The following apps need to get updated:
- [x] Examples
- [x] Test app, https://github.com/mattermost/mattermost-app-test/pull/11
- [x] ~~ServiceNow~~
- [x] ~~Zendesk~~