### PR TITLE
Add check for i18n files to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,17 @@ jobs:
           command: |
             make mock
             git --no-pager diff --exit-code server/mocks* || (echo "Please run \"make mock\" and commit the changes in the generated files." && exit 1)
+  check-i18n:
+    docker:
+      - image: circleci/golang:1.16.0
+    steps:
+      - checkout
+      - run:
+          name: Checking if extracted i18n files are up to date
+          command: |
+            go install github.com/nicksnyder/go-i18n/v2/goi18n@v2.1.2
+            make i18n-extract-server
+            git --no-pager diff --exit-code assets/i18n/* || (echo "Please run \"make i18n-extract-server\" and commit the changes in the generated files." && exit 1)
 
   test-e2e-postgres11:
     docker:
@@ -288,6 +299,7 @@ workflows:
                 - master
     jobs:
       - check-mocks
+      - check-i18n
       - plugin-ci/lint
       - plugin-ci/test
       - e2e-cypress-tests-pinned
@@ -296,7 +308,11 @@ workflows:
       - plugin-ci/build
   ci:
     jobs:
-      -  check-mocks:
+      - check-mocks:
+          filters:
+            tags:
+              only: /^v.*/
+      - check-i18n:
           filters:
             tags:
               only: /^v.*/
@@ -328,6 +344,7 @@ workflows:
           context: plugin-ci
           requires:
             - check-mocks
+            - check-i18n
             - plugin-ci/lint
             - plugin-ci/coverage
             - test-e2e-postgres11
@@ -343,6 +360,7 @@ workflows:
           context: matterbuild-github-token
           requires:
             - check-mocks
+            - check-i18n
             - plugin-ci/lint
             - plugin-ci/coverage
             - test-e2e-postgres11

--- a/build/custom.mk
+++ b/build/custom.mk
@@ -7,6 +7,7 @@ LDFLAGS += -X "github.com/mattermost/mattermost-plugin-api/experimental/telemetr
 
 default: all
 
+.PHONY: i18n-extract-server
 i18n-extract-server:
 	@goi18n extract -format json -outdir assets/i18n/ server/ utils/ apps/ cmd/ upstream/
 	@for x in assets/i18n/active.*.json; do echo $$x | sed 's/active/translate/' | sed 's/^/touch /' | bash; done
@@ -15,6 +16,7 @@ i18n-extract-server:
 	@echo "If you don't want to change any locale file, simply remove the assets/i18n/translate.??.json file before calling \"make i18n-merge-server\""
 	@echo "If you want to add a new language (for example french), simply run \"touch assets/i18n/active.fr.json\" and then run the \"make i18n-extract-server\" again"
 
+.PHONY: i18n-merge-server
 i18n-merge-server:
 	@goi18n merge -format json -outdir assets/i18n/ assets/i18n/active.*.json assets/i18n/translate.*.json
 	@rm -f assets/i18n/translate.*.json


### PR DESCRIPTION
#### Summary
Fixated the version of `go-i18n` to `v2.1.2` to avoid compatibility issues in the future.

#### Ticket Link
https://github.com/mattermost/mattermost-plugin-apps/pull/285#issuecomment-958752420
