### PR TITLE
[MM-40134] Reduce appID length to 26 characters

### DIFF
--- a/apps/manifest.go
+++ b/apps/manifest.go
@@ -216,7 +216,7 @@ type AppID string
 
 const (
 	MinAppIDLength = 3
-	MaxAppIDLength = 32
+	MaxAppIDLength = 26
 )
 
 func (id AppID) Validate() error {

--- a/apps/manifest_test.go
+++ b/apps/manifest_test.go
@@ -15,19 +15,19 @@ func TestValidateAppID(t *testing.T) {
 	t.Parallel()
 
 	for id, valid := range map[string]bool{
-		"":                                  false,
-		"a":                                 false,
-		"ab":                                false,
-		"abc":                               true,
-		"abcdefghijklmnopqrstuvwxyzabcdef":  true,
-		"abcdefghijklmnopqrstuvwxyzabcdefg": false,
-		"../path":                           false,
-		"/etc/passwd":                       false,
-		"com.mattermost.app-0.9":            true,
-		"CAPS-ARE-FINE":                     true,
-		"....DOTS.ALSO.......":              true,
-		"----SLASHES-ALSO----":              true,
-		"___AND_UNDERSCORES____":            true,
+		"":                            false,
+		"a":                           false,
+		"ab":                          false,
+		"abc":                         true,
+		"abcdefghijklmnopqrstuvwxyz":  true,
+		"abcdefghijklmnopqrstuvwxyza": false,
+		"../path":                     false,
+		"/etc/passwd":                 false,
+		"com.mattermost.app-0.9":      true,
+		"CAPS-ARE-FINE":               true,
+		"....DOTS.ALSO.......":        true,
+		"----SLASHES-ALSO----":        true,
+		"___AND_UNDERSCORES____":      true,
 	} {
 		t.Run(id, func(t *testing.T) {
 			err := apps.AppID(id).Validate()


### PR DESCRIPTION
#### Summary
To avoid issues like the one in https://mattermost.atlassian.net/browse/MM-34968 and to unify the length with other IDs length in the MM ecosystem this PR reduces the appID length to 26 characters.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40134

