### PR TITLE
Fix subpath for local requests

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -112,7 +112,7 @@ func (conf *Config) Update(stored StoredConfig, mmconf *model.Config, license *m
 			host = "127.0.0.1"
 		}
 
-		localURL = "http://" + host + ":" + port
+		localURL = "http://" + host + ":" + port + mattermostURL.Path
 	}
 
 	conf.StoredConfig = stored

--- a/server/httpin/restapi/restapitestlib.go
+++ b/server/httpin/restapi/restapitestlib.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
 
@@ -137,7 +138,16 @@ func (th *TestHelper) SetupApp(t *testing.T, m apps.Manifest) {
 }
 
 func (th *TestHelper) CreateClientPP() *appclient.ClientPP {
-	return appclient.NewAppsPluginAPIClient(fmt.Sprintf("http://localhost:%v", th.ServerTestHelper.App.Srv().ListenAddr.Port))
+	port := th.ServerTestHelper.App.Srv().ListenAddr.Port
+
+	subpath := ""
+	siteURL := th.ServerTestHelper.App.Srv().Config().ServiceSettings.SiteURL
+	if siteURL != nil && *siteURL != "" {
+		u, _ := url.Parse(*siteURL)
+		subpath = u.Path
+	}
+
+	return appclient.NewAppsPluginAPIClient(fmt.Sprintf("http://localhost:%v%v", port, subpath))
 }
 
 func (th *TestHelper) CreateLocalClient(socketPath string) *appclient.ClientPP {

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -38,7 +38,7 @@ func TestOnActivate(t *testing.T) {
 	testAPI.On("LoadPluginConfiguration", mock.AnythingOfType("*config.StoredConfig")).Return(nil)
 
 	listenAddress := "localhost:8065"
-	siteURL := "http://" + listenAddress
+	siteURL := "http://" + listenAddress + "/subpath"
 	testAPI.On("GetConfig").Return(&model.Config{
 		ServiceSettings: model.ServiceSettings{
 			SiteURL:       &siteURL,


### PR DESCRIPTION
#### Summary

When we create a `Client4` struct for local HTTP requests, we construct the URL manually using the `ListenAddress`, but we don't take into account the server's configured subpath on the site URL. This PR uses the `SiteURL` to calculate the subpath for the constructed URL.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-40195