### PR TITLE
Updated assets/manifests.json to include solely servicenow v0.3.0

### DIFF
--- a/assets/manifests.json
+++ b/assets/manifests.json
@@ -1,4 +1,3 @@
 {
-    "com.mattermost.servicenow": "0.2.0",
-    "com.mattermost.zendesk": "0.2.1"
+    "com.mattermost.servicenow": "0.3.0"
 }


### PR DESCRIPTION
#### Summary
Updated the list of Cloud apps to be limited to ServiceNow v0.3.0

Should be merged once https://github.com/mattermost/mattermost-app-servicenow/pull/37 is merged (and deployed)