### PR TITLE
Avoid stripping context values if call is for built-in app

### DIFF
--- a/server/proxy/expand.go
+++ b/server/proxy/expand.go
@@ -151,13 +151,15 @@ func (p *Proxy) expandContext(r *incoming.Request, app apps.App, base *apps.Cont
 		}
 	}
 
-	// Cleanup fields for app
-	cc.UserAgentContext.ChannelID = ""
-	cc.UserAgentContext.TeamID = ""
-	cc.UserAgentContext.RootPostID = ""
-	cc.UserAgentContext.PostID = ""
-	cc.UserID = ""
-	cc.ActingUserID = ""
+	if app.DeployType != apps.DeployBuiltin {
+		// Cleanup fields for app
+		cc.UserAgentContext.ChannelID = ""
+		cc.UserAgentContext.TeamID = ""
+		cc.UserAgentContext.RootPostID = ""
+		cc.UserAgentContext.PostID = ""
+		cc.UserID = ""
+		cc.ActingUserID = ""
+	}
 
 	return cc, nil
 }


### PR DESCRIPTION
#### Summary

When the install form is submitted, the Apps framework will send the form submission (including the info about the current channel/team) to the "built-in app" used to orchestrate the state of installed apps. When the call is prepared for the built-in app, the team id and channel id are stripped from the context during the context expansion. The built-in app then tries to use its received context when expanding for the `OnInstall` call, but it doesn't have access to the stripped values.

This PR makes it so the values are only stripped when the call is meant for an app other than the built-in app.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-43436
