### PR TITLE
disabled MessageHasBeenPosted processing

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,7 +34,6 @@ linters:
     - misspell
     - nakedret
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert

--- a/apps/subscription.go
+++ b/apps/subscription.go
@@ -50,15 +50,18 @@ const (
 	// used to expand other entities.
 	SubjectChannelCreated Subject = "channel_created"
 
+	// TODO: re-enable post_created and bot_mentioned once perf issues are
+	// resolved, see https://mattermost.atlassian.net/browse/MM-44388
+
 	// SubjectPostCreated subscribes to MessageHasBeenPosted plugin events, for
 	// the specified channel. By default notifications include UserID (author), PostID,
 	// RootPostID, ChannelID, but only Post is fully expanded. Expand can be
 	// used to expand other entities.
-	SubjectPostCreated Subject = "post_created"
+	// SubjectPostCreated Subject = "post_created"
 
 	// SubjectBotMentioned subscribes to MessageHasBeenPosted plugin events, specifically
 	// when the App's bot is mentioned in the post.
-	SubjectBotMentioned Subject = "bot_mentioned"
+	// SubjectBotMentioned Subject = "bot_mentioned"
 )
 
 // Subscription is submitted by an app to the Subscribe API. It determines what
@@ -100,8 +103,7 @@ func (sub Subscription) Validate() error {
 		SubjectBotJoinedChannel,
 		SubjectBotLeftChannel,
 		SubjectBotJoinedTeam,
-		SubjectBotLeftTeam,
-		SubjectBotMentioned:
+		SubjectBotLeftTeam /*, SubjectBotMentioned*/ :
 		if sub.TeamID != "" {
 			result = multierror.Append(result, utils.NewInvalidError("teamID must be empty"))
 		}
@@ -110,8 +112,7 @@ func (sub Subscription) Validate() error {
 		}
 
 	case SubjectUserJoinedChannel,
-		SubjectUserLeftChannel,
-		SubjectPostCreated:
+		SubjectUserLeftChannel /*, SubjectPostCreated */ :
 		if sub.TeamID != "" {
 			result = multierror.Append(result, utils.NewInvalidError("teamID must be empty"))
 		}

--- a/server/appservices/subscriptions.go
+++ b/server/appservices/subscriptions.go
@@ -27,15 +27,11 @@ func CheckSubscriptionPermission(checker PermissionChecker, sub apps.Subscriptio
 		if !checker.HasPermissionTo(userID, model.PermissionViewMembers) {
 			return errors.New("no permission to read user")
 		}
-	case apps.SubjectUserJoinedChannel,
-		apps.SubjectUserLeftChannel,
-		apps.SubjectPostCreated:
+	case apps.SubjectUserJoinedChannel, apps.SubjectUserLeftChannel /*, apps.SubjectPostCreated */ :
 		if !checker.HasPermissionToChannel(userID, sub.ChannelID, model.PermissionReadChannel) {
 			return errors.New("no permission to read channel")
 		}
-	case apps.SubjectBotJoinedChannel,
-		apps.SubjectBotLeftChannel,
-		apps.SubjectBotMentioned:
+	case apps.SubjectBotJoinedChannel, apps.SubjectBotLeftChannel /*, apps.SubjectBotMentioned*/ :
 		// Only check if there is dynamic context i.e. a channelID
 		if channelID != "" {
 			if !checker.HasPermissionToChannel(userID, channelID, model.PermissionReadChannel) {

--- a/server/mocks/mock_proxy/mock_proxy.go
+++ b/server/mocks/mock_proxy/mock_proxy.go
@@ -16,7 +16,6 @@ import (
 	proxy "github.com/mattermost/mattermost-plugin-apps/server/proxy"
 	upstream "github.com/mattermost/mattermost-plugin-apps/upstream"
 	utils "github.com/mattermost/mattermost-plugin-apps/utils"
-	model "github.com/mattermost/mattermost-server/v6/model"
 )
 
 // MockService is a mock of Service interface.
@@ -289,20 +288,6 @@ func (m *MockService) Notify(arg0 apps.Context, arg1 apps.Subject) error {
 func (mr *MockServiceMockRecorder) Notify(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Notify", reflect.TypeOf((*MockService)(nil).Notify), arg0, arg1)
-}
-
-// NotifyMessageHasBeenPosted mocks base method.
-func (m *MockService) NotifyMessageHasBeenPosted(arg0 *model.Post, arg1 apps.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NotifyMessageHasBeenPosted", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// NotifyMessageHasBeenPosted indicates an expected call of NotifyMessageHasBeenPosted.
-func (mr *MockServiceMockRecorder) NotifyMessageHasBeenPosted(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyMessageHasBeenPosted", reflect.TypeOf((*MockService)(nil).NotifyMessageHasBeenPosted), arg0, arg1)
 }
 
 // NotifyRemoteWebhook mocks base method.

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -233,32 +233,32 @@ func (p *Plugin) UserHasLeftTeam(_ *plugin.Context, tm *model.TeamMember, acting
 	}
 }
 
-func (p *Plugin) MessageHasBeenPosted(_ *plugin.Context, post *model.Post) {
-	shouldProcessMessage, err := p.conf.MattermostAPI().Post.ShouldProcessMessage(post, pluginapi.BotID(p.conf.Get().BotUserID))
-	if err != nil {
-		p.log.WithError(err).Errorf("Error while checking if the message should be processed")
-		return
-	}
+// func (p *Plugin) MessageHasBeenPosted(_ *plugin.Context, post *model.Post) {
+// 	shouldProcessMessage, err := p.conf.MattermostAPI().Post.ShouldProcessMessage(post, pluginapi.BotID(p.conf.Get().BotUserID))
+// 	if err != nil {
+// 		p.log.WithError(err).Errorf("Error while checking if the message should be processed")
+// 		return
+// 	}
 
-	if !shouldProcessMessage {
-		return
-	}
+// 	if !shouldProcessMessage {
+// 		return
+// 	}
 
-	err = p.proxy.NotifyMessageHasBeenPosted(post, apps.Context{
-		UserAgentContext: apps.UserAgentContext{
-			PostID:     post.Id,
-			RootPostID: post.RootId,
-			ChannelID:  post.ChannelId,
-		},
-		UserID: post.UserId,
-		ExpandedContext: apps.ExpandedContext{
-			Post: post,
-		},
-	})
-	if err != nil {
-		p.log.WithError(err).Debugf("Error handling MessageHasBeenPosted")
-	}
-}
+// 	err = p.proxy.NotifyMessageHasBeenPosted(post, apps.Context{
+// 		UserAgentContext: apps.UserAgentContext{
+// 			PostID:     post.Id,
+// 			RootPostID: post.RootId,
+// 			ChannelID:  post.ChannelId,
+// 		},
+// 		UserID: post.UserId,
+// 		ExpandedContext: apps.ExpandedContext{
+// 			Post: post,
+// 		},
+// 	})
+// 	if err != nil {
+// 		p.log.WithError(err).Debugf("Error handling MessageHasBeenPosted")
+// 	}
+// }
 
 func (p *Plugin) ChannelHasBeenCreated(_ *plugin.Context, ch *model.Channel) {
 	err := p.proxy.Notify(

--- a/server/proxy/notify.go
+++ b/server/proxy/notify.go
@@ -5,12 +5,8 @@ package proxy
 
 import (
 	"context"
-	"regexp"
-	"strings"
 
 	"github.com/pkg/errors"
-
-	"github.com/mattermost/mattermost-server/v6/model"
 
 	"github.com/mattermost/mattermost-plugin-apps/apps"
 	"github.com/mattermost/mattermost-plugin-apps/server/appservices"
@@ -82,49 +78,49 @@ func (p *Proxy) notifyForSubscription(r *incoming.Request, base *apps.Context, s
 	return upstream.Notify(r.Ctx(), up, *app, creq)
 }
 
-func (p *Proxy) NotifyMessageHasBeenPosted(post *model.Post, cc apps.Context) error {
-	ctx, cancel := context.WithTimeout(context.Background(), config.RequestTimeout)
-	defer cancel()
+// func (p *Proxy) NotifyMessageHasBeenPosted(post *model.Post, cc apps.Context) error {
+// 	ctx, cancel := context.WithTimeout(context.Background(), config.RequestTimeout)
+// 	defer cancel()
 
-	mm := p.conf.MattermostAPI()
-	r := incoming.NewRequest(mm, p.conf, utils.NewPluginLogger(mm), p.sessionService, incoming.WithCtx(ctx))
+// 	mm := p.conf.MattermostAPI()
+// 	r := incoming.NewRequest(mm, p.conf, utils.NewPluginLogger(mm), p.sessionService, incoming.WithCtx(ctx))
 
-	postSubs, err := p.store.Subscription.Get(apps.SubjectPostCreated, cc.TeamID, cc.ChannelID)
-	if err != nil && err != utils.ErrNotFound {
-		return errors.Wrap(err, "failed to get post_created subscriptions")
-	}
+// 	postSubs, err := p.store.Subscription.Get(apps.SubjectPostCreated, cc.TeamID, cc.ChannelID)
+// 	if err != nil && err != utils.ErrNotFound {
+// 		return errors.Wrap(err, "failed to get post_created subscriptions")
+// 	}
 
-	subs := []apps.Subscription{}
-	subs = append(subs, postSubs...)
+// 	subs := []apps.Subscription{}
+// 	subs = append(subs, postSubs...)
 
-	mentions := possibleAtMentions(post.Message)
+// 	mentions := possibleAtMentions(post.Message)
 
-	if len(mentions) > 0 {
-		appsMap := p.store.App.AsMap()
-		mentionSubs, err := p.store.Subscription.Get(apps.SubjectBotMentioned, cc.TeamID, cc.ChannelID)
-		if err != nil && err != utils.ErrNotFound {
-			return errors.Wrap(err, "failed to get bot_mentioned subscriptions")
-		}
+// 	if len(mentions) > 0 {
+// 		appsMap := p.store.App.AsMap()
+// 		mentionSubs, err := p.store.Subscription.Get(apps.SubjectBotMentioned, cc.TeamID, cc.ChannelID)
+// 		if err != nil && err != utils.ErrNotFound {
+// 			return errors.Wrap(err, "failed to get bot_mentioned subscriptions")
+// 		}
 
-		for _, sub := range mentionSubs {
-			app, ok := appsMap[sub.AppID]
-			if !ok {
-				continue
-			}
-			for _, mention := range mentions {
-				if mention == app.BotUsername {
-					subs = append(subs, sub)
-				}
-			}
-		}
-	}
+// 		for _, sub := range mentionSubs {
+// 			app, ok := appsMap[sub.AppID]
+// 			if !ok {
+// 				continue
+// 			}
+// 			for _, mention := range mentions {
+// 				if mention == app.BotUsername {
+// 					subs = append(subs, sub)
+// 				}
+// 			}
+// 		}
+// 	}
 
-	if len(subs) == 0 {
-		return nil
-	}
+// 	if len(subs) == 0 {
+// 		return nil
+// 	}
 
-	return p.notify(r, cc, subs)
-}
+// 	return p.notify(r, cc, subs)
+// }
 
 func (p *Proxy) NotifyUserHasJoinedChannel(cc apps.Context) error {
 	return p.notifyJoinLeave(cc, apps.SubjectUserJoinedChannel, apps.SubjectBotJoinedChannel)
@@ -177,24 +173,24 @@ func (p *Proxy) notifyJoinLeave(cc apps.Context, subject, botSubject apps.Subjec
 	return p.notify(r, cc, subs)
 }
 
-var atMentionRegexp = regexp.MustCompile(`\B@[[:alnum:]][[:alnum:]\.\-_:]*`)
+// var atMentionRegexp = regexp.MustCompile(`\B@[[:alnum:]][[:alnum:]\.\-_:]*`)
 
-// possibleAtMentions is copied over from mattermost-server/app.possibleAtMentions
-func possibleAtMentions(message string) []string {
-	var names []string
+// // possibleAtMentions is copied over from mattermost-server/app.possibleAtMentions
+// func possibleAtMentions(message string) []string {
+// 	var names []string
 
-	if !strings.Contains(message, "@") {
-		return names
-	}
+// 	if !strings.Contains(message, "@") {
+// 		return names
+// 	}
 
-	alreadyMentioned := make(map[string]bool)
-	for _, match := range atMentionRegexp.FindAllString(message, -1) {
-		name := model.NormalizeUsername(match[1:])
-		if !alreadyMentioned[name] && model.IsValidUsernameAllowRemote(name) {
-			names = append(names, name)
-			alreadyMentioned[name] = true
-		}
-	}
+// 	alreadyMentioned := make(map[string]bool)
+// 	for _, match := range atMentionRegexp.FindAllString(message, -1) {
+// 		name := model.NormalizeUsername(match[1:])
+// 		if !alreadyMentioned[name] && model.IsValidUsernameAllowRemote(name) {
+// 			names = append(names, name)
+// 			alreadyMentioned[name] = true
+// 		}
+// 	}
 
-	return names
-}
+// 	return names
+// }

--- a/server/proxy/notify_test.go
+++ b/server/proxy/notify_test.go
@@ -57,6 +57,135 @@ var app2 = apps.App{
 	},
 }
 
+// func TestNotifyMessageHasBeenPosted(t *testing.T) {
+// 	for _, tc := range []notifyTestcase{
+// 		{
+// 			name: "post_created no subscriptions",
+// 			subs: map[string][]apps.Subscription{
+// 				"sub.bot_mentioned":                {},
+// 				"sub.post_created.some_channel_id": {},
+// 			},
+// 			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
+// 				message := "Hey @bot2username!"
+// 				post := &model.Post{
+// 					Message: message,
+// 				}
+// 				err := p.NotifyMessageHasBeenPosted(post, apps.Context{
+// 					UserAgentContext: apps.UserAgentContext{
+// 						ChannelID: "some_channel_id",
+// 					},
+// 				})
+// 				require.NoError(t, err)
+// 			},
+// 		},
+// 		{
+// 			name: "post_created",
+// 			subs: map[string][]apps.Subscription{
+// 				"sub.bot_mentioned": {},
+// 				"sub.post_created.some_channel_id": {
+// 					{
+// 						AppID:     app1.AppID,
+// 						UserID:    "some_user_id",
+// 						Subject:   apps.SubjectPostCreated,
+// 						ChannelID: "some_channel_id",
+// 						Call:      *apps.NewCall("/notify/post_created"),
+// 					},
+// 				},
+// 			},
+// 			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
+// 				sendCallResponse(t, "/notify/post_created", apps.NewDataResponse(nil), up[app1.AppID])
+
+// 				message := "Hey @bot2username!"
+// 				post := &model.Post{
+// 					Message: message,
+// 				}
+// 				testAPI.On("HasPermissionToChannel", "some_user_id", "some_channel_id", model.PermissionReadChannel).Return(true)
+
+// 				err := p.NotifyMessageHasBeenPosted(post, apps.Context{
+// 					UserAgentContext: apps.UserAgentContext{
+// 						ChannelID: "some_channel_id",
+// 					},
+// 				})
+// 				require.NoError(t, err)
+// 			},
+// 		},
+// 		{
+// 			name: "bot_mentioned, member of channel",
+// 			subs: map[string][]apps.Subscription{
+// 				"sub.post_created.some_channel_id": {},
+// 				"sub.bot_mentioned": {
+// 					{
+// 						AppID:   app1.AppID,
+// 						UserID:  "some_user_id",
+// 						Subject: apps.SubjectBotMentioned,
+// 						Call:    *apps.NewCall("/notify/bot_mention1"),
+// 					},
+// 					{
+// 						AppID:   app2.AppID,
+// 						UserID:  "some_user_id",
+// 						Subject: apps.SubjectBotMentioned,
+// 						Call:    *apps.NewCall("/notify/bot_mention2"),
+// 					},
+// 				},
+// 			},
+// 			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
+// 				sendCallResponse(t, "/notify/bot_mention2", apps.NewDataResponse(nil), up[app2.AppID])
+
+// 				message := "Hey @bot2username!"
+// 				post := &model.Post{
+// 					Message: message,
+// 				}
+// 				testAPI.On("HasPermissionToChannel", "some_user_id", "some_channel_id", model.PermissionReadChannel).Return(true)
+// 				err := p.NotifyMessageHasBeenPosted(post, apps.Context{
+// 					UserAgentContext: apps.UserAgentContext{
+// 						ChannelID: "some_channel_id",
+// 					},
+// 				})
+// 				require.NoError(t, err)
+// 			},
+// 		},
+// 		{
+// 			name: "bot_mentioned, member of channel",
+// 			subs: map[string][]apps.Subscription{
+// 				"sub.post_created.some_channel_id": {},
+// 				"sub.bot_mentioned": {
+// 					{
+// 						AppID:   app1.AppID,
+// 						UserID:  "some_user_id",
+// 						Subject: apps.SubjectBotMentioned,
+// 						Call:    *apps.NewCall("/notify/bot_mention1"),
+// 					},
+// 					{
+// 						AppID:   app2.AppID,
+// 						UserID:  "some_user_id",
+// 						Subject: apps.SubjectBotMentioned,
+// 						Call:    *apps.NewCall("/notify/bot_mention2"),
+// 					},
+// 				},
+// 			},
+// 			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
+// 				message := "Hey @bot2username!"
+// 				post := &model.Post{
+// 					Message: message,
+// 				}
+
+// 				testAPI.On("HasPermissionToChannel", "some_user_id", "some_channel_id", model.PermissionReadChannel).Return(false)
+
+// 				err := p.NotifyMessageHasBeenPosted(post, apps.Context{
+// 					UserAgentContext: apps.UserAgentContext{
+// 						ChannelID: "some_channel_id",
+// 					},
+// 				})
+// 				require.NoError(t, err)
+// 			},
+// 		},
+// 	} {
+// 		t.Run(tc.name, func(t *testing.T) {
+// 			runNotifyTest(t, []apps.App{app1, app2}, tc)
+// 		})
+// 	}
+// }
+
 func TestUserHasJoinedChannel(t *testing.T) {
 	for _, tc := range []notifyTestcase{
 		{
@@ -513,132 +642,3 @@ func runNotifyTest(t *testing.T, allApps []apps.App, tc notifyTestcase) {
 
 	tc.run(p, upMockMap, api)
 }
-
-// func TestNotifyMessageHasBeenPosted(t *testing.T) {
-// 	for _, tc := range []notifyTestcase{
-// 		{
-// 			name: "post_created no subscriptions",
-// 			subs: map[string][]apps.Subscription{
-// 				"sub.bot_mentioned":                {},
-// 				"sub.post_created.some_channel_id": {},
-// 			},
-// 			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
-// 				message := "Hey @bot2username!"
-// 				post := &model.Post{
-// 					Message: message,
-// 				}
-// 				err := p.NotifyMessageHasBeenPosted(post, apps.Context{
-// 					UserAgentContext: apps.UserAgentContext{
-// 						ChannelID: "some_channel_id",
-// 					},
-// 				})
-// 				require.NoError(t, err)
-// 			},
-// 		},
-// 		{
-// 			name: "post_created",
-// 			subs: map[string][]apps.Subscription{
-// 				"sub.bot_mentioned": {},
-// 				"sub.post_created.some_channel_id": {
-// 					{
-// 						AppID:     app1.AppID,
-// 						UserID:    "some_user_id",
-// 						Subject:   apps.SubjectPostCreated,
-// 						ChannelID: "some_channel_id",
-// 						Call:      *apps.NewCall("/notify/post_created"),
-// 					},
-// 				},
-// 			},
-// 			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
-// 				sendCallResponse(t, "/notify/post_created", apps.NewDataResponse(nil), up[app1.AppID])
-
-// 				message := "Hey @bot2username!"
-// 				post := &model.Post{
-// 					Message: message,
-// 				}
-// 				testAPI.On("HasPermissionToChannel", "some_user_id", "some_channel_id", model.PermissionReadChannel).Return(true)
-
-// 				err := p.NotifyMessageHasBeenPosted(post, apps.Context{
-// 					UserAgentContext: apps.UserAgentContext{
-// 						ChannelID: "some_channel_id",
-// 					},
-// 				})
-// 				require.NoError(t, err)
-// 			},
-// 		},
-// 		{
-// 			name: "bot_mentioned, member of channel",
-// 			subs: map[string][]apps.Subscription{
-// 				"sub.post_created.some_channel_id": {},
-// 				"sub.bot_mentioned": {
-// 					{
-// 						AppID:   app1.AppID,
-// 						UserID:  "some_user_id",
-// 						Subject: apps.SubjectBotMentioned,
-// 						Call:    *apps.NewCall("/notify/bot_mention1"),
-// 					},
-// 					{
-// 						AppID:   app2.AppID,
-// 						UserID:  "some_user_id",
-// 						Subject: apps.SubjectBotMentioned,
-// 						Call:    *apps.NewCall("/notify/bot_mention2"),
-// 					},
-// 				},
-// 			},
-// 			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
-// 				sendCallResponse(t, "/notify/bot_mention2", apps.NewDataResponse(nil), up[app2.AppID])
-
-// 				message := "Hey @bot2username!"
-// 				post := &model.Post{
-// 					Message: message,
-// 				}
-// 				testAPI.On("HasPermissionToChannel", "some_user_id", "some_channel_id", model.PermissionReadChannel).Return(true)
-// 				err := p.NotifyMessageHasBeenPosted(post, apps.Context{
-// 					UserAgentContext: apps.UserAgentContext{
-// 						ChannelID: "some_channel_id",
-// 					},
-// 				})
-// 				require.NoError(t, err)
-// 			},
-// 		},
-// 		{
-// 			name: "bot_mentioned, member of channel",
-// 			subs: map[string][]apps.Subscription{
-// 				"sub.post_created.some_channel_id": {},
-// 				"sub.bot_mentioned": {
-// 					{
-// 						AppID:   app1.AppID,
-// 						UserID:  "some_user_id",
-// 						Subject: apps.SubjectBotMentioned,
-// 						Call:    *apps.NewCall("/notify/bot_mention1"),
-// 					},
-// 					{
-// 						AppID:   app2.AppID,
-// 						UserID:  "some_user_id",
-// 						Subject: apps.SubjectBotMentioned,
-// 						Call:    *apps.NewCall("/notify/bot_mention2"),
-// 					},
-// 				},
-// 			},
-// 			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
-// 				message := "Hey @bot2username!"
-// 				post := &model.Post{
-// 					Message: message,
-// 				}
-
-// 				testAPI.On("HasPermissionToChannel", "some_user_id", "some_channel_id", model.PermissionReadChannel).Return(false)
-
-// 				err := p.NotifyMessageHasBeenPosted(post, apps.Context{
-// 					UserAgentContext: apps.UserAgentContext{
-// 						ChannelID: "some_channel_id",
-// 					},
-// 				})
-// 				require.NoError(t, err)
-// 			},
-// 		},
-// 	} {
-// 		t.Run(tc.name, func(t *testing.T) {
-// 			runNotifyTest(t, []apps.App{app1, app2}, tc)
-// 		})
-// 	}
-// }

--- a/server/proxy/notify_test.go
+++ b/server/proxy/notify_test.go
@@ -57,135 +57,6 @@ var app2 = apps.App{
 	},
 }
 
-func TestNotifyMessageHasBeenPosted(t *testing.T) {
-	for _, tc := range []notifyTestcase{
-		{
-			name: "post_created no subscriptions",
-			subs: map[string][]apps.Subscription{
-				"sub.bot_mentioned":                {},
-				"sub.post_created.some_channel_id": {},
-			},
-			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
-				message := "Hey @bot2username!"
-				post := &model.Post{
-					Message: message,
-				}
-				err := p.NotifyMessageHasBeenPosted(post, apps.Context{
-					UserAgentContext: apps.UserAgentContext{
-						ChannelID: "some_channel_id",
-					},
-				})
-				require.NoError(t, err)
-			},
-		},
-		{
-			name: "post_created",
-			subs: map[string][]apps.Subscription{
-				"sub.bot_mentioned": {},
-				"sub.post_created.some_channel_id": {
-					{
-						AppID:     app1.AppID,
-						UserID:    "some_user_id",
-						Subject:   apps.SubjectPostCreated,
-						ChannelID: "some_channel_id",
-						Call:      *apps.NewCall("/notify/post_created"),
-					},
-				},
-			},
-			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
-				sendCallResponse(t, "/notify/post_created", apps.NewDataResponse(nil), up[app1.AppID])
-
-				message := "Hey @bot2username!"
-				post := &model.Post{
-					Message: message,
-				}
-				testAPI.On("HasPermissionToChannel", "some_user_id", "some_channel_id", model.PermissionReadChannel).Return(true)
-
-				err := p.NotifyMessageHasBeenPosted(post, apps.Context{
-					UserAgentContext: apps.UserAgentContext{
-						ChannelID: "some_channel_id",
-					},
-				})
-				require.NoError(t, err)
-			},
-		},
-		{
-			name: "bot_mentioned, member of channel",
-			subs: map[string][]apps.Subscription{
-				"sub.post_created.some_channel_id": {},
-				"sub.bot_mentioned": {
-					{
-						AppID:   app1.AppID,
-						UserID:  "some_user_id",
-						Subject: apps.SubjectBotMentioned,
-						Call:    *apps.NewCall("/notify/bot_mention1"),
-					},
-					{
-						AppID:   app2.AppID,
-						UserID:  "some_user_id",
-						Subject: apps.SubjectBotMentioned,
-						Call:    *apps.NewCall("/notify/bot_mention2"),
-					},
-				},
-			},
-			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
-				sendCallResponse(t, "/notify/bot_mention2", apps.NewDataResponse(nil), up[app2.AppID])
-
-				message := "Hey @bot2username!"
-				post := &model.Post{
-					Message: message,
-				}
-				testAPI.On("HasPermissionToChannel", "some_user_id", "some_channel_id", model.PermissionReadChannel).Return(true)
-				err := p.NotifyMessageHasBeenPosted(post, apps.Context{
-					UserAgentContext: apps.UserAgentContext{
-						ChannelID: "some_channel_id",
-					},
-				})
-				require.NoError(t, err)
-			},
-		},
-		{
-			name: "bot_mentioned, member of channel",
-			subs: map[string][]apps.Subscription{
-				"sub.post_created.some_channel_id": {},
-				"sub.bot_mentioned": {
-					{
-						AppID:   app1.AppID,
-						UserID:  "some_user_id",
-						Subject: apps.SubjectBotMentioned,
-						Call:    *apps.NewCall("/notify/bot_mention1"),
-					},
-					{
-						AppID:   app2.AppID,
-						UserID:  "some_user_id",
-						Subject: apps.SubjectBotMentioned,
-						Call:    *apps.NewCall("/notify/bot_mention2"),
-					},
-				},
-			},
-			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
-				message := "Hey @bot2username!"
-				post := &model.Post{
-					Message: message,
-				}
-
-				testAPI.On("HasPermissionToChannel", "some_user_id", "some_channel_id", model.PermissionReadChannel).Return(false)
-
-				err := p.NotifyMessageHasBeenPosted(post, apps.Context{
-					UserAgentContext: apps.UserAgentContext{
-						ChannelID: "some_channel_id",
-					},
-				})
-				require.NoError(t, err)
-			},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			runNotifyTest(t, []apps.App{app1, app2}, tc)
-		})
-	}
-}
-
 func TestUserHasJoinedChannel(t *testing.T) {
 	for _, tc := range []notifyTestcase{
 		{
@@ -642,3 +513,132 @@ func runNotifyTest(t *testing.T, allApps []apps.App, tc notifyTestcase) {
 
 	tc.run(p, upMockMap, api)
 }
+
+// func TestNotifyMessageHasBeenPosted(t *testing.T) {
+// 	for _, tc := range []notifyTestcase{
+// 		{
+// 			name: "post_created no subscriptions",
+// 			subs: map[string][]apps.Subscription{
+// 				"sub.bot_mentioned":                {},
+// 				"sub.post_created.some_channel_id": {},
+// 			},
+// 			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
+// 				message := "Hey @bot2username!"
+// 				post := &model.Post{
+// 					Message: message,
+// 				}
+// 				err := p.NotifyMessageHasBeenPosted(post, apps.Context{
+// 					UserAgentContext: apps.UserAgentContext{
+// 						ChannelID: "some_channel_id",
+// 					},
+// 				})
+// 				require.NoError(t, err)
+// 			},
+// 		},
+// 		{
+// 			name: "post_created",
+// 			subs: map[string][]apps.Subscription{
+// 				"sub.bot_mentioned": {},
+// 				"sub.post_created.some_channel_id": {
+// 					{
+// 						AppID:     app1.AppID,
+// 						UserID:    "some_user_id",
+// 						Subject:   apps.SubjectPostCreated,
+// 						ChannelID: "some_channel_id",
+// 						Call:      *apps.NewCall("/notify/post_created"),
+// 					},
+// 				},
+// 			},
+// 			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
+// 				sendCallResponse(t, "/notify/post_created", apps.NewDataResponse(nil), up[app1.AppID])
+
+// 				message := "Hey @bot2username!"
+// 				post := &model.Post{
+// 					Message: message,
+// 				}
+// 				testAPI.On("HasPermissionToChannel", "some_user_id", "some_channel_id", model.PermissionReadChannel).Return(true)
+
+// 				err := p.NotifyMessageHasBeenPosted(post, apps.Context{
+// 					UserAgentContext: apps.UserAgentContext{
+// 						ChannelID: "some_channel_id",
+// 					},
+// 				})
+// 				require.NoError(t, err)
+// 			},
+// 		},
+// 		{
+// 			name: "bot_mentioned, member of channel",
+// 			subs: map[string][]apps.Subscription{
+// 				"sub.post_created.some_channel_id": {},
+// 				"sub.bot_mentioned": {
+// 					{
+// 						AppID:   app1.AppID,
+// 						UserID:  "some_user_id",
+// 						Subject: apps.SubjectBotMentioned,
+// 						Call:    *apps.NewCall("/notify/bot_mention1"),
+// 					},
+// 					{
+// 						AppID:   app2.AppID,
+// 						UserID:  "some_user_id",
+// 						Subject: apps.SubjectBotMentioned,
+// 						Call:    *apps.NewCall("/notify/bot_mention2"),
+// 					},
+// 				},
+// 			},
+// 			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
+// 				sendCallResponse(t, "/notify/bot_mention2", apps.NewDataResponse(nil), up[app2.AppID])
+
+// 				message := "Hey @bot2username!"
+// 				post := &model.Post{
+// 					Message: message,
+// 				}
+// 				testAPI.On("HasPermissionToChannel", "some_user_id", "some_channel_id", model.PermissionReadChannel).Return(true)
+// 				err := p.NotifyMessageHasBeenPosted(post, apps.Context{
+// 					UserAgentContext: apps.UserAgentContext{
+// 						ChannelID: "some_channel_id",
+// 					},
+// 				})
+// 				require.NoError(t, err)
+// 			},
+// 		},
+// 		{
+// 			name: "bot_mentioned, member of channel",
+// 			subs: map[string][]apps.Subscription{
+// 				"sub.post_created.some_channel_id": {},
+// 				"sub.bot_mentioned": {
+// 					{
+// 						AppID:   app1.AppID,
+// 						UserID:  "some_user_id",
+// 						Subject: apps.SubjectBotMentioned,
+// 						Call:    *apps.NewCall("/notify/bot_mention1"),
+// 					},
+// 					{
+// 						AppID:   app2.AppID,
+// 						UserID:  "some_user_id",
+// 						Subject: apps.SubjectBotMentioned,
+// 						Call:    *apps.NewCall("/notify/bot_mention2"),
+// 					},
+// 				},
+// 			},
+// 			run: func(p *Proxy, up map[apps.AppID]*mock_upstream.MockUpstream, testAPI *plugintest.API) {
+// 				message := "Hey @bot2username!"
+// 				post := &model.Post{
+// 					Message: message,
+// 				}
+
+// 				testAPI.On("HasPermissionToChannel", "some_user_id", "some_channel_id", model.PermissionReadChannel).Return(false)
+
+// 				err := p.NotifyMessageHasBeenPosted(post, apps.Context{
+// 					UserAgentContext: apps.UserAgentContext{
+// 						ChannelID: "some_channel_id",
+// 					},
+// 				})
+// 				require.NoError(t, err)
+// 			},
+// 		},
+// 	} {
+// 		t.Run(tc.name, func(t *testing.T) {
+// 			runNotifyTest(t, []apps.App{app1, app2}, tc)
+// 		})
+// 	}
+// }

--- a/server/proxy/service.go
+++ b/server/proxy/service.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost-plugin-api/cluster"
-	"github.com/mattermost/mattermost-server/v6/model"
 
 	"github.com/mattermost/mattermost-plugin-apps/apps"
 	"github.com/mattermost/mattermost-plugin-apps/apps/appclient"
@@ -68,7 +67,7 @@ type Invoker interface {
 type Notifier interface {
 	Notify(apps.Context, apps.Subject) error
 	NotifyRemoteWebhook(*incoming.Request, apps.AppID, apps.HTTPCallRequest) error
-	NotifyMessageHasBeenPosted(*model.Post, apps.Context) error
+	// NotifyMessageHasBeenPosted(*model.Post, apps.Context) error
 	NotifyUserHasJoinedChannel(apps.Context) error
 	NotifyUserHasLeftChannel(apps.Context) error
 	NotifyUserHasJoinedTeam(apps.Context) error

--- a/server/store/subscriptions.go
+++ b/server/store/subscriptions.go
@@ -34,12 +34,10 @@ func subsKey(subject apps.Subject, teamID, channelID string) (string, error) {
 		apps.SubjectBotJoinedChannel,
 		apps.SubjectBotLeftChannel,
 		apps.SubjectBotJoinedTeam,
-		apps.SubjectBotLeftTeam,
-		apps.SubjectBotMentioned:
+		apps.SubjectBotLeftTeam /*, apps.SubjectBotMentioned */ :
 		// Global, no suffix
 	case apps.SubjectUserJoinedChannel,
-		apps.SubjectUserLeftChannel,
-		apps.SubjectPostCreated:
+		apps.SubjectUserLeftChannel /* , apps.SubjectPostCreated */ :
 		idSuffix = "." + channelID
 	case apps.SubjectUserJoinedTeam,
 		apps.SubjectUserLeftTeam,

--- a/server/store/subscriptions_test.go
+++ b/server/store/subscriptions_test.go
@@ -323,12 +323,12 @@ func TestSubsKey(t *testing.T) {
 			"channel-id",
 			"sub.channel_created.team-id",
 		},
-		string(apps.SubjectPostCreated): {
-			apps.SubjectPostCreated,
-			"team-id",
-			"channel-id",
-			"sub.post_created.channel-id",
-		},
+		// string(apps.SubjectPostCreated): {
+		// 	apps.SubjectPostCreated,
+		// 	"team-id",
+		// 	"channel-id",
+		// 	"sub.post_created.channel-id",
+		// },
 	} {
 		t.Run(name, func(t *testing.T) {
 			r, err := subsKey(testcase.Subject, testcase.TeamID, testcase.ChannelID)

--- a/test/app/subscriptions.go
+++ b/test/app/subscriptions.go
@@ -39,11 +39,11 @@ var allSubjects = map[apps.Subject]apps.Expand{
 		Team:       apps.ExpandAll,
 		TeamMember: apps.ExpandAll,
 	},
-	apps.SubjectBotMentioned: {
-		Channel:  apps.ExpandAll,
-		Post:     apps.ExpandSummary,
-		RootPost: apps.ExpandSummary,
-	},
+	// apps.SubjectBotMentioned: {
+	// 	Channel:  apps.ExpandAll,
+	// 	Post:     apps.ExpandSummary,
+	// 	RootPost: apps.ExpandSummary,
+	// },
 	apps.SubjectUserJoinedChannel: {
 		User:          apps.ExpandAll,
 		Channel:       apps.ExpandAll,
@@ -54,10 +54,10 @@ var allSubjects = map[apps.Subject]apps.Expand{
 		Channel:       apps.ExpandAll,
 		ChannelMember: apps.ExpandAll,
 	},
-	apps.SubjectPostCreated: {
-		Post:    apps.ExpandAll,
-		Channel: apps.ExpandAll,
-	},
+	// apps.SubjectPostCreated: {
+	// 	Post:    apps.ExpandAll,
+	// 	Channel: apps.ExpandAll,
+	// },
 	apps.SubjectUserJoinedTeam: {
 		User:       apps.ExpandAll,
 		Team:       apps.ExpandAll,
@@ -126,8 +126,7 @@ func handleSubscription(creq *apps.CallRequest, subscribe bool) apps.CallRespons
 
 	switch subject {
 	case apps.SubjectUserJoinedChannel,
-		apps.SubjectBotLeftChannel,
-		apps.SubjectPostCreated:
+		apps.SubjectBotLeftChannel /*, apps.SubjectPostCreated*/ :
 		sub.ChannelID = creq.Context.Channel.Id
 
 	case apps.SubjectUserJoinedTeam,


### PR DESCRIPTION
#### Summary
Disabled MessageHasBeenPosted and the related subscription subjects until we figure out performance issues. This disables both `post_created` and `bot_mentioned` notifications.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-44388