### PR TITLE
/apps debug is now dev mode only, other feedback from DH

### DIFF
--- a/server/builtin/bindings.go
+++ b/server/builtin/bindings.go
@@ -18,8 +18,10 @@ func (a *builtinApp) getBindings(creq apps.CallRequest, loc *i18n.Localizer) []a
 	}
 
 	if creq.Context.ActingUser != nil && creq.Context.ActingUser.IsSystemAdmin() {
+		if a.conf.Get().DeveloperMode {
+			commands = append(commands, a.debugCommandBinding(loc))
+		}
 		commands = append(commands,
-			a.debugCommandBinding(loc),
 			a.disableCommandBinding(loc),
 			a.enableCommandBinding(loc),
 			a.installCommandBinding(loc),

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -141,6 +141,7 @@ func (conf *Config) update(stored StoredConfig, mmconf *model.Config, license *m
 
 	conf.AllowHTTPApps = !conf.MattermostCloudMode || conf.DeveloperMode
 	if allowHTTPAppsDomains.MatchString(u.Hostname()) {
+		log.Debugf("set AllowHTTPApps based on the hostname '%s'", u.Hostname())
 		conf.AllowHTTPApps = true
 	}
 

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -4,10 +4,19 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildConfig(t *testing.T) {
 	assert.NotEmpty(t, BuildDate)
 	assert.NotEmpty(t, BuildHash)
 	assert.NotEmpty(t, BuildHashShort)
+}
+
+func TestAllowHTTPRegexp(t *testing.T) {
+	require.False(t, allowHTTPAppsDomains.MatchString("dkh-apps-upgrade.cloud.mattermost.com"))
+	require.True(t, allowHTTPAppsDomains.MatchString("dkh-apps-upgrade.test.mattermost.cloud"))
+	require.True(t, allowHTTPAppsDomains.MatchString("community.mattermost.com"))
+	require.True(t, allowHTTPAppsDomains.MatchString("community-daily.mattermost.com"))
+	require.True(t, allowHTTPAppsDomains.MatchString("community-release.mattermost.com"))
 }

--- a/server/proxy/list.go
+++ b/server/proxy/list.go
@@ -28,7 +28,7 @@ func (p *Proxy) GetInstalledApp(_ *incoming.Request, appID apps.AppID) (*apps.Ap
 func (p *Proxy) GetInstalledApps(r *incoming.Request, ping bool) (installed []apps.App, reachable map[apps.AppID]bool) {
 	all := p.store.App.AsMap()
 
-	if ping {
+	if ping && len(all) > 0 {
 		// all ping requests must respond, unreachable respond with "".
 		reachableCh := make(chan apps.AppID)
 		defer close(reachableCh)


### PR DESCRIPTION
#### Summary
- `/apps debug` command is now only visible in dev mode
- @DHaussermann reported seeing HTTP enabled on a production host, so added debugging to see why the regex matches falsely
- Added a small optimization to GetInstalledApps - don't even make a channel if there are no apps installed

#### Ticket Link
None