### PR TITLE
[MM-43756] Remove unused fields in apps.Binding

### DIFF
--- a/apps/binding.go
+++ b/apps/binding.go
@@ -185,9 +185,6 @@ type Binding struct {
 	//  - in-post: is the text of the embed
 	Description string `json:"description,omitempty"`
 
-	// RoleID is a role required to see the item (hidden for other users).
-	RoleID string `json:"role_id,omitempty"`
-
 	// A Binding is either an action, a form (embedded or fetched), or a
 	// "container" for other locations/bindings - i.e. menu sub-items or
 	// subcommands. An attempt to specify more than one of these fields is


### PR DESCRIPTION
#### Summary
Per https://docs.google.com/document/d/1INuXoRopTb9rHQ_3egXOUXtwaSOtbLtR-GTJghxzh68 the `DependsOnX` fields will not longer be used. This PR removes them to avoid confusion. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43756
