### PR TITLE
fixed the test app

### DIFF
--- a/cmd/appsctl/mattermost.go
+++ b/cmd/appsctl/mattermost.go
@@ -20,7 +20,7 @@ func getMattermostClient() (*appclient.Client, error) {
 		return nil, errors.New("MM_SERVICESETTINGS_SITEURL and MM_ADMIN_TOKEN must be set")
 	}
 
-	return appclient.NewClient("", adminToken, siteURL), nil
+	return appclient.NewClient(adminToken, siteURL), nil
 }
 
 func updateMattermost(m apps.Manifest, deployType apps.DeployType, installApp bool) error {

--- a/test/app/subscriptions.go
+++ b/test/app/subscriptions.go
@@ -127,11 +127,13 @@ func handleSubscription(creq *apps.CallRequest, subscribe bool) apps.CallRespons
 
 	switch subject {
 	case apps.SubjectUserJoinedChannel,
-		apps.SubjectBotLeftChannel /*, apps.SubjectPostCreated*/ :
+		apps.SubjectUserLeftChannel:
 		sub.ChannelID = creq.Context.Channel.Id
 
 	case apps.SubjectUserJoinedTeam,
 		apps.SubjectUserLeftTeam,
+		apps.SubjectBotJoinedChannel,
+		apps.SubjectBotLeftChannel,
 		apps.SubjectChannelCreated:
 		sub.TeamID = creq.Context.Team.Id
 	}


### PR DESCRIPTION
- appclient no longer requires a userID to work
- `DM[Post]` errors out if the creator's user ID is not known, with a `empty sender user_id, perhaps Call does not expand acting_user` message. Note that the Bot user id is always expanded.
- Fixed the test apps' subscription parameters

@DHaussermann I did not review every expand in the test app, but it does not use `DM` nor `DMPost` so should be OK.

Embedded does not appear to work, will debug it separately, perhaps @mickmister can help?