### PR TITLE
MM-43962: Added support for .jar files in appsctl aws

### DIFF
--- a/cmd/appsctl/aws.go
+++ b/cmd/appsctl/aws.go
@@ -33,6 +33,7 @@ func init() {
 	awsDeployCmd.Flags().BoolVar(&shouldUpdate, "update", false, "Update functions if they already exist. Use with caution in production.")
 	awsDeployCmd.Flags().StringVar(&invokePolicyName, "policy", upaws.DefaultPolicyName, "name of the policy used to invoke Apps on AWS.")
 	awsDeployCmd.Flags().StringVar(&executeRoleName, "execute-role", upaws.DefaultExecuteRoleName, "name of the role to be assumed by running Lambdas.")
+	awsDeployCmd.Flags().StringToStringVar(&environment, "env", nil, "environment variables to pass to the App")
 
 	// clean
 	awsCmd.AddCommand(awsCleanCmd)
@@ -123,6 +124,7 @@ var awsDeployCmd = &cobra.Command{
 			InvokePolicyName: upaws.Name(invokePolicyName),
 			ExecuteRoleName:  upaws.Name(executeRoleName),
 			ShouldUpdate:     shouldUpdate,
+			Environment:      environment,
 		})
 		if err != nil {
 			return err

--- a/cmd/appsctl/main.go
+++ b/cmd/appsctl/main.go
@@ -25,6 +25,7 @@ var (
 	shouldCreateAccessKey bool
 	shouldUpdate          bool
 	userName              string
+	environment           map[string]string
 )
 
 func init() {

--- a/upstream/upaws/client.go
+++ b/upstream/upaws/client.go
@@ -6,6 +6,7 @@ package upaws
 import (
 	"context"
 	"io"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -52,6 +53,7 @@ type Client interface {
 	CreateGroup(name Name) (ARN, error)
 	CreateLambda(zipFile io.Reader, function, handler, runtime string, role ARN) (ARN, error)
 	CreateOrUpdateLambda(zipFile io.Reader, function, handler, runtime string, role ARN) (ARN, error)
+	SetLambdaEnvironmentVariables(arn string, started time.Time, vars map[string]*string) error
 	CreatePolicy(name Name, data string) (ARN, error)
 	CreateRole(name Name) (ARN, error)
 	CreateS3Bucket(bucket string) error

--- a/upstream/upaws/client_lambda.go
+++ b/upstream/upaws/client_lambda.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -96,6 +97,50 @@ func (c *client) CreateOrUpdateLambda(zipFile io.Reader, function, handler, runt
 	}
 	c.log.Infow("updated function", "ARN", *fc.Configuration.FunctionArn)
 	return ARN(*fc.Configuration.FunctionArn), nil
+}
+
+const updateWaitTime = 2 * time.Minute
+
+// SetLambdaEnvironmentVariables sets environment variables for a lambda
+// function. It waits until an function code deployment succeeds before updating
+// the configuration.
+func (c *client) SetLambdaEnvironmentVariables(arn string, started time.Time, vars map[string]*string) error {
+	deadline := started.Add(updateWaitTime)
+	retry := 5 * time.Second
+
+RETRY:
+	for time.Now().Before(deadline) {
+		fc, err := c.lambda.GetFunctionConfiguration(&lambda.GetFunctionConfigurationInput{
+			FunctionName: aws.String(arn),
+		})
+		if err != nil {
+			return errors.Wrapf(err, "failed to get function configuration for %s", arn)
+		}
+
+		switch *fc.LastUpdateStatus {
+		case "Successful":
+			break RETRY
+		case "Failed":
+			return errors.New("can't set environment variables after a failed deployment")
+		default:
+			c.log.Infof("function deployment %s, will wait %v", *fc.LastUpdateStatus, retry)
+			time.Sleep(retry)
+			retry *= 2
+		}
+	}
+
+	_, err := c.lambda.UpdateFunctionConfiguration(&lambda.UpdateFunctionConfigurationInput{
+		FunctionName: aws.String(arn),
+		Environment: &lambda.Environment{
+			Variables: vars,
+		},
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to update function configuration for %s", arn)
+	}
+
+	c.log.Infof("set %v environment variables on %s", len(vars), arn)
+	return nil
 }
 
 // LambdaName generates function name for a specific app, name can be 64

--- a/upstream/upaws/client_lambda.go
+++ b/upstream/upaws/client_lambda.go
@@ -40,14 +40,14 @@ func (c *client) InvokeLambda(ctx context.Context, name, invocationType string, 
 }
 
 // CreateLambda method creates lambda function
-func (c *client) CreateLambda(zipFile io.Reader, name, handler, runtime string, roleARN ARN) (ARN, error) {
-	if zipFile == nil || name == "" || handler == "" || roleARN == "" || runtime == "" {
-		return "", errors.Errorf("you must supply a zip file, function name, handler, role ARN and runtime - %p %q %q %q %q", zipFile, name, handler, roleARN, runtime)
+func (c *client) CreateLambda(archive io.Reader, name, handler, runtime string, roleARN ARN) (ARN, error) {
+	if archive == nil || name == "" || handler == "" || roleARN == "" || runtime == "" {
+		return "", errors.Errorf("you must supply an archive (.zip or .jar) file, function name, handler, role ARN and runtime - %p %q %q %q %q", archive, name, handler, roleARN, runtime)
 	}
 
-	contents, err := io.ReadAll(zipFile)
+	contents, err := io.ReadAll(archive)
 	if err != nil {
-		return "", errors.Wrap(err, "could not read zip file")
+		return "", errors.Wrap(err, "could not read archive file")
 	}
 
 	createCode := &lambda.FunctionCode{

--- a/upstream/upaws/provision_data.go
+++ b/upstream/upaws/provision_data.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
@@ -70,8 +71,9 @@ func getDeployData(b []byte, log utils.Logger) (*DeployData, error) {
 
 	// Read all the files from zip archive
 	for _, file := range bundleReader.File {
+		extension := filepath.Ext(file.Name)
 		switch {
-		case strings.HasSuffix(file.Name, "manifest.json"):
+		case file.Name == "manifest.json":
 			manifestFile, err := file.Open()
 			if err != nil {
 				return nil, errors.Wrap(err, "can't open manifest.json file")
@@ -88,14 +90,14 @@ func getDeployData(b []byte, log utils.Logger) (*DeployData, error) {
 			}
 			log.Infow("found manifest", "file", file.Name)
 
-		case strings.HasSuffix(file.Name, ".zip"):
+		case extension == ".zip" || extension == ".jar":
 			lambdaFunctionFile, err := file.Open()
 			if err != nil {
 				return nil, errors.Wrapf(err, "can't open file %s", file.Name)
 			}
 			defer lambdaFunctionFile.Close()
 			bundleFunctions = append(bundleFunctions, FunctionData{
-				Name:   strings.TrimSuffix(file.Name, ".zip"),
+				Name:   strings.TrimSuffix(file.Name, extension),
 				Bundle: lambdaFunctionFile,
 			})
 			log.Infow("found lambda function bundle", "file", file.Name)

--- a/upstream/upaws/provision_data.go
+++ b/upstream/upaws/provision_data.go
@@ -78,6 +78,7 @@ func getDeployData(b []byte, log utils.Logger) (*DeployData, error) {
 			if err != nil {
 				return nil, errors.Wrap(err, "can't open manifest.json file")
 			}
+			// The uploaded manifest will be generated, so we can close the source file now.
 			defer manifestFile.Close()
 
 			data, err := io.ReadAll(manifestFile)
@@ -95,7 +96,7 @@ func getDeployData(b []byte, log utils.Logger) (*DeployData, error) {
 			if err != nil {
 				return nil, errors.Wrapf(err, "can't open file %s", file.Name)
 			}
-			defer lambdaFunctionFile.Close()
+			// lambdaFunctionFile will be closed when the function is deployed.
 			bundleFunctions = append(bundleFunctions, FunctionData{
 				Name:   strings.TrimSuffix(file.Name, extension),
 				Bundle: lambdaFunctionFile,
@@ -111,6 +112,7 @@ func getDeployData(b []byte, log utils.Logger) (*DeployData, error) {
 			if err != nil {
 				return nil, errors.Wrapf(err, "can't open file %s", file.Name)
 			}
+			// assetFile will be closed when the function is deployed.
 			assets = append(assets, AssetData{
 				Key:  assetName,
 				File: assetFile,


### PR DESCRIPTION
#### Summary
`appsctl aws deploy` now supports:
-  `.jar` file extensions, in addition to .zip. (.jar is essentially a .zip with a special metadata directory).
- `--env='k1=v1,k2=v2'` option for passing environment variables to the deployed Lambda functions

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-43962
https://mattermost.atlassian.net/browse/MM-43961
