### PR TITLE
Add developer route to refresh bindings on demand

### DIFF
--- a/apps/appclient/mattermost_client_pp.go
+++ b/apps/appclient/mattermost_client_pp.go
@@ -148,6 +148,16 @@ func (c *ClientPP) Unsubscribe(sub *apps.Subscription) (*model.Response, error) 
 	return model.BuildResponse(r), nil
 }
 
+func (c *ClientPP) RefreshBindings(userID string) (*model.Response, error) {
+	r, err := c.DoAPIPOST(c.apipath(appspath.RefreshBindings + "?user_id=" + userID), "") // nolint:bodyclose
+	if err != nil {
+		return model.BuildResponse(r), err
+	}
+	defer c.closeBody(r)
+
+	return model.BuildResponse(r), nil
+}
+
 func (c *ClientPP) StoreOAuth2App(oauth2App apps.OAuth2App) (*model.Response, error) {
 	r, err := c.DoAPIPOST(c.apipath(appspath.OAuth2App), utils.ToJSON(oauth2App)) // nolint:bodyclose
 	if err != nil {

--- a/apps/path/paths.go
+++ b/apps/path/paths.go
@@ -16,6 +16,7 @@ const (
 	OAuth2User        = "/oauth2/user"
 	Subscribe         = "/subscribe"
 	Unsubscribe       = "/unsubscribe"
+	RefreshBindings   = "/refresh_bindings"
 
 	// Invoke.
 	Call = "/call"

--- a/server/appservices/dev.go
+++ b/server/appservices/dev.go
@@ -1,0 +1,17 @@
+package appservices
+
+import (
+	"github.com/mattermost/mattermost-plugin-apps/server/config"
+	"github.com/mattermost/mattermost-plugin-apps/server/incoming"
+	"github.com/mattermost/mattermost-server/v6/model"
+)
+
+func (a *AppServices) RefreshBindings(r *incoming.Request, userID string) error {
+	err := r.RequireSourceApp()
+	if err != nil {
+		return err
+	}
+
+	r.Config().MattermostAPI().Frontend.PublishWebSocketEvent(config.WebSocketEventRefreshBindings, map[string]interface{}{}, &model.WebsocketBroadcast{UserId: userID})
+	return err
+}

--- a/server/appservices/service.go
+++ b/server/appservices/service.go
@@ -31,6 +31,10 @@ type Service interface {
 	StoreOAuth2App(_ *incoming.Request, data []byte) error
 	StoreOAuth2User(_ *incoming.Request, data []byte) error
 	GetOAuth2User(_ *incoming.Request) ([]byte, error)
+
+	// Development
+
+	RefreshBindings(_ *incoming.Request, userID string) error
 }
 
 type AppServices struct {

--- a/server/appservices/service.go
+++ b/server/appservices/service.go
@@ -32,7 +32,7 @@ type Service interface {
 	StoreOAuth2User(_ *incoming.Request, data []byte) error
 	GetOAuth2User(_ *incoming.Request) ([]byte, error)
 
-	// Development
+	// Developer
 
 	RefreshBindings(_ *incoming.Request, userID string) error
 }

--- a/server/httpin/dev.go
+++ b/server/httpin/dev.go
@@ -1,0 +1,21 @@
+package httpin
+
+import (
+	"net/http"
+
+	"github.com/mattermost/mattermost-plugin-apps/server/incoming"
+	"github.com/mattermost/mattermost-plugin-apps/utils/httputils"
+)
+
+func (s *Service) RefreshBindings(r *incoming.Request, w http.ResponseWriter, req *http.Request) {
+	if !*s.Config.MattermostConfig().Config().ServiceSettings.EnableDeveloper {
+		http.Error(w, "Development route unreachable due to disabled EnableDeveloper config setting", http.StatusBadRequest)
+		return
+	}
+
+	userID := req.URL.Query().Get("user_id")
+	if err := s.AppServices.RefreshBindings(r, userID); err != nil {
+		http.Error(w, err.Error(), httputils.ErrorToStatus(err))
+		return
+	}
+}

--- a/server/httpin/service.go
+++ b/server/httpin/service.go
@@ -87,7 +87,7 @@ func NewService(proxy proxy.Service, appservices appservices.Service, conf confi
 	h.HandleFunc(path.Subscribe, h.Subscribe).Methods(http.MethodPost)
 	h.HandleFunc(path.Unsubscribe, h.Unsubscribe).Methods(http.MethodPost)
 
-	// Development routes, intended to be used by Apps. `EnableDeveloper` must be enabled to use these.
+	// Developer routes, intended to be used by Apps in development cycle. `EnableDeveloper` must be enabled to use these routes.
 
 	h.HandleFunc(path.RefreshBindings, h.RefreshBindings).Methods(http.MethodPost)
 

--- a/server/httpin/service.go
+++ b/server/httpin/service.go
@@ -87,6 +87,10 @@ func NewService(proxy proxy.Service, appservices appservices.Service, conf confi
 	h.HandleFunc(path.Subscribe, h.Subscribe).Methods(http.MethodPost)
 	h.HandleFunc(path.Unsubscribe, h.Unsubscribe).Methods(http.MethodPost)
 
+	// Development routes, intended to be used by Apps. `EnableDeveloper` must be enabled to use these.
+
+	h.HandleFunc(path.RefreshBindings, h.RefreshBindings).Methods(http.MethodPost)
+
 	// Admin API, can be used by plugins, external services, or the user agent.
 	h.HandleFunc(path.DisableApp, h.DisableApp).Methods(http.MethodPost)
 	h.HandleFunc(path.EnableApp, h.EnableApp).Methods(http.MethodPost)


### PR DESCRIPTION
#### Summary

This PR adds an endpoint `/api/v1/refresh_bindings` that will send a `refresh_bindings` websocket message to a given user.

This is especially useful during a rapid development cycle. As soon as my App is redeployed locally after some change, the App's start-up sequence can ping the Apps plugin to refresh the client's bindings.

This criteria is required for this to occur:

- `EnableDeveloper` is enabled
- The request is coming from an App
- A user id is provided in url params

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-46901