### PR TITLE
Fix e2e tests for webapp master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -445,7 +445,7 @@ workflows:
       - e2e-cypress-tests-master:
           filters:
             branches:
-              only: master
+              only: /^v.*/
           requires:
             - lint
       - test-rest-postgres11:

--- a/test/e2e/cypress/support/index.ts
+++ b/test/e2e/cypress/support/index.ts
@@ -6,3 +6,7 @@
 // ***********************************************************
 
 import 'mattermost-webapp/e2e/cypress/tests/support';
+
+before(() => {
+    localStorage.setItem('__landingPageSeen__', String(true));
+});


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

This PR fixes the issue where the e2e test would get stuck on the webapp's landing page to open the desktop app.

As a follow up to https://github.com/mattermost/mattermost-plugin-apps/pull/362#issuecomment-1279257314, I tried using the test app rather than the hello app for the e2e tests, but the test app currently doesn't test things like sending bot DMs, so it's currently not available to be a drop-in replacement.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

