### PR TITLE
Update golangci-lint version and fix linter errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,34 @@ commands:
           from: << parameters.filename >>
           to: << parameters.bucket >>
           arguments: "--acl public-read --cache-control no-cache"
+  install-golangci-lint:
+    description: Install golangci-lint
+    parameters:
+      version:
+        type: string
+        default: 1.49.0
+      gobin:
+        type: string
+        default: $GOPATH/bin
+      prefix:
+        type: string
+        default: v2
+        description: Prefix for cache key to store the binary.
+    steps:
+      - restore_cache:
+          name: Restore golangci-lint cache
+          keys: ['<< parameters.prefix >>-golangci-lint-{{ arch }}-<< parameters.version >>']
+      - run:
+          name: Install golangci-lint
+          command: |
+            mkdir -p << parameters.gobin >>
+            command -v << parameters.gobin >>/golangci-lint && exit
+            download=https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
+            wget -O- -q $download | sh -s -- -b << parameters.gobin >>/ v<< parameters.version >>
+      - save_cache:
+          name: Save golangci-lint cache
+          key: '<< parameters.prefix >>-golangci-lint-{{ arch }}-<< parameters.version >>'
+          paths: [<< parameters.gobin >>/golangci-lint]
 
 jobs:
   lint:
@@ -49,6 +77,7 @@ jobs:
     steps:
       - checkout
       - *restore_go_cache
+      - install-golangci-lint
       - run:
           name: Checking code style
           command: make check-style

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,8 +7,6 @@ linters-settings:
     simplify: true
   goimports:
     local-prefixes: github.com/mattermost/mattermost-plugin-apps
-  golint:
-    min-confidence: 0
   govet:
     check-shadowing: true
     enable-all: true
@@ -21,12 +19,10 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - errcheck
     - gocritic
     - gofmt
     - goimports
-    - golint
     - gosec
     - gosimple
     - govet
@@ -35,11 +31,11 @@ linters:
     - nakedret
     - staticcheck
     - stylecheck
+    - revive
     - typecheck
     - unconvert
     - unused
     - unparam
-    - varcheck
     - whitespace
 
 issues:
@@ -47,20 +43,14 @@ issues:
     - path: server/incoming/request.go
       linters: 
         - govet
-    - path: server/manifest.go
-      linters:
-        - deadcode
-        - unused
-        - varcheck
-    - path: server/configuration.go
-      linters:
-        - unused
     - path: _test\.go
       linters:
         - bodyclose
         - scopelint # https://github.com/kyoh86/scopelint/issues/4
-    - path: test/restapi
+    - path: test/restapitest
       linters:
+        - bodyclose
         - unused
+        - unparam
 
 

--- a/apps/binding.go
+++ b/apps/binding.go
@@ -8,7 +8,7 @@ package apps
 // (mandatory) "bindings" call. It can also add bindings to messages (posts) in
 // Mattermost, by setting "app_bindings" property of the posts.
 //
-// Mattermost UI Bindings
+// # Mattermost UI Bindings
 //
 // An App returns its bindings in response to the "bindings" call, that it must
 // implement, and can customize in its Manifest. For each context in which it is
@@ -16,21 +16,23 @@ package apps
 // top-level location.
 //
 // Top level bindings need to define:
-//  location - the top-level location to bind to, e.g. "post_menu".
-//  bindings - an array of bindings
+//   - location - the top-level location to bind to, e.g. "post_menu".
+//   - bindings - an array of bindings
 //
 // /post_menu bindings need to define:
-//  location - Name of this location. The whole path of locations will be added in the context.
-//  icon - optional URL or path to the icon
-//  label - Text to show in the item
-//  call - Call to perform.
+//
+//   - location - Name of this location. The whole path of locations will be added in the context.
+//   - icon - optional URL or path to the icon
+//   - label - Text to show in the item
+//   - call - Call to perform.
 //
 // /channel_header bindings need to define:
-//  location - Name of this location. The whole path of locations will be added in the context.
-//  icon - optional URL or path to the icon
-//  label - text to show in the item on mobile and webapp collapsed view.
-//  hint - text to show in the webapp's tooltip.
-//  call - Call to perform.
+//
+//   - location - Name of this location. The whole path of locations will be added in the context.
+//   - icon - optional URL or path to the icon
+//   - label - text to show in the item on mobile and webapp collapsed view.
+//   - hint - text to show in the webapp's tooltip.
+//   - call - [Call] to perform.
 //
 // /command bindings can define "inner" subcommands that are collections of more
 // bindings/subcommands, and "outer" subcommands that implement forms and can be
@@ -39,18 +41,20 @@ package apps
 // subcommand, accomplishing similar user experience.
 //
 // Inner command bindings need to define:
-//  label - the label for the command itself.
-//  location - the location of the command, defaults to label.
-//  hint - Hint line in autocomplete.
-//  description - description line in autocomplete.
-//  bindings - subcommands
+//
+//   - label - the label for the command itself.
+//   - location - the location of the command, defaults to label.
+//   - hint - Hint line in autocomplete.
+//   - description - description line in autocomplete.
+//   - bindings - subcommands
 //
 // Outer command bindings need to define:
-//  label - the label for the command itself.
-//  location - the location of the command, defaults to label.
-//  hint - Hint line in autocomplete.
-//  description - description line in autocomplete.
-//  call or form - either embed a form, or provide a call to fetch it.
+//
+//   - label - the label for the command itself.
+//   - location - the location of the command, defaults to label.
+//   - hint - Hint line in autocomplete.
+//   - description - description line in autocomplete.
+//   - call or form - either embed a form, or provide a call to fetch it.
 //
 // Bindings are currently refreshed when a user visits a channel, in the context
 // of the current channel, from all the registered Apps. A server-side cache
@@ -60,45 +64,46 @@ package apps
 //
 // Example bindings (hello world app) create a button in the channel header, and
 // a "/helloworld send" command:
-//  {
-//      "type": "ok",
-//      "data": [
-//          {
-//              "location": "/channel_header",
-//              "bindings": [
-//                  {
-//                      "location": "send-button",
-//                      "icon": "icon.png",
-//                      "label":"send hello message",
-//                      "call": {
-//                          "path": "/send-modal"
-//                      }
-//                  }
-//              ]
-//          },
-//          {
-//              "location": "/command",
-//              "bindings": [
-//                  {
-//                      "icon": "icon.png",
-//                      "description": "Hello World app",
-//                      "hint":        "[send]",
-//                      "bindings": [
-//                          {
-//                              "location": "send",
-//                              "label": "send",
-//                              "call": {
-//                                  "path": "/send"
-//                              }
-//                          }
-//                      ]
-//                  }
-//              ]
-//          }
-//      ]
-//  }
 //
-// In-post Bindings
+//	{
+//	    "type": "ok",
+//	    "data": [
+//	        {
+//	            "location": "/channel_header",
+//	            "bindings": [
+//	                {
+//	                    "location": "send-button",
+//	                    "icon": "icon.png",
+//	                    "label":"send hello message",
+//	                    "call": {
+//	                        "path": "/send-modal"
+//	                    }
+//	                }
+//	            ]
+//	        },
+//	        {
+//	            "location": "/command",
+//	            "bindings": [
+//	                {
+//	                    "icon": "icon.png",
+//	                    "description": "Hello World app",
+//	                    "hint":        "[send]",
+//	                    "bindings": [
+//	                        {
+//	                            "location": "send",
+//	                            "label": "send",
+//	                            "call": {
+//	                                "path": "/send"
+//	                            }
+//	                        }
+//	                    ]
+//	                }
+//	            ]
+//	        }
+//	    ]
+//	}
+//
+// # In-post Bindings
 //
 // An App can also create messages (posts) in Mattermost with in-post bindings.
 // To do that, it invokes `CreatePost` REST API, and sets the "app_bindings"
@@ -115,43 +120,42 @@ package apps
 // be rendered as a select. You can identify the action triggered by the
 // location.
 //
-//  {
-//     channel_id: "channelID",
-//     message: "Some message to appear before the attachment",
-//     props: {
-//         app_bindings: [{
-//             app_id: "my app id",
-//             location: "location",
-//             label: "title of the attachment",
-//             description: "body of the attachment",
-//             bindings: [
-//                 {
-//                     location: "my_select",
-//                     label: "Placeholder text",
-//                     bindings: [
-//                         {
-//                             location: "option1",
-//                             label: "Option 1",
-//                         }, {
-//                             location: "option2",
-//                             label: "Option 2",
-//                         },
-//                     ],
-//                     call: {
-//                         path: "my/path",
-//                     },
-//                 }, {
-//                     location: "my_button",
-//                     label: "Button label",
-//                     call: {
-//                         path: "my/path",
-//                     },
-//                 },
-//             ],
-//         }],
-//     },
-//  }
-//
+//	{
+//	   channel_id: "channelID",
+//	   message: "Some message to appear before the attachment",
+//	   props: {
+//	       app_bindings: [{
+//	           app_id: "my app id",
+//	           location: "location",
+//	           label: "title of the attachment",
+//	           description: "body of the attachment",
+//	           bindings: [
+//	               {
+//	                   location: "my_select",
+//	                   label: "Placeholder text",
+//	                   bindings: [
+//	                       {
+//	                           location: "option1",
+//	                           label: "Option 1",
+//	                       }, {
+//	                           location: "option2",
+//	                           label: "Option 2",
+//	                       },
+//	                   ],
+//	                   call: {
+//	                       path: "my/path",
+//	                   },
+//	               }, {
+//	                   location: "my_button",
+//	                   label: "Button label",
+//	                   call: {
+//	                       path: "my/path",
+//	                   },
+//	               },
+//	           ],
+//	       }],
+//	   },
+//	}
 type Binding struct {
 	// For internal use by Mattermost, Apps do not need to set.
 	AppID AppID `json:"app_id,omitempty"`

--- a/apps/goapp/app.go
+++ b/apps/goapp/app.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"runtime/debug"
 	"testing"
+	"time"
 	"unicode"
 
 	"github.com/gorilla/mux"
@@ -189,11 +190,16 @@ func (app *App) RunHTTP() {
 		app.Manifest.Deploy.HTTP.RootURL = "http://localhost:" + portStr
 	}
 
-	http.Handle("/", app.Router)
-
 	listen := ":" + portStr
+	server := &http.Server{
+		Addr:              listen,
+		ReadHeaderTimeout: 3 * time.Second,
+		WriteTimeout:      5 * time.Second,
+		Handler:           app.Router,
+	}
+
 	app.log.Infof("%s started, listening on port %s, manifest at `%s/manifest.json`; use environment variables PORT and ROOT_URL to customize.", app.Manifest.AppID, portStr, app.Manifest.Deploy.HTTP.RootURL)
-	panic(http.ListenAndServe(listen, nil))
+	panic(server.ListenAndServe())
 }
 
 func pathFromName(name string) string {

--- a/apps/package.go
+++ b/apps/package.go
@@ -6,14 +6,14 @@
 //
 // Main documentation: https://developers.mattermost.com/integrate/apps/
 //
-// Function
+// # Function
 //
 // Functions are invoked in response to a user or a notification event. A
 // Function to invoke is described by a Call, and is passed a CallRequest when
 // invoked. For user-invoked functions, the inputs can be collected from the
 // user with a Form, either as a modal, or as a /command with autocomplete.
 //
-// Call
+// # Call
 //
 // A Call is a general request to an App server. Calls are used to fetch App's
 // bindings, and to process user input, webhook events, and dynamic data
@@ -23,7 +23,7 @@
 // originating Call, and adds user-input values, Context, etc. CallResponse is
 // the result of a call.
 //
-// Context and Expand
+// # Context and Expand
 //
 // Context of a CallRequest sent to the App includes the IDs of relevant
 // Mattermost entities, such as the Location the call originated from, acting
@@ -42,9 +42,9 @@
 //
 // Special Notes
 //
-//  - TODO Use of router packages in Apps - Go (gorilla mux) - JavaScript
+//   - TODO Use of router packages in Apps - Go (gorilla mux) - JavaScript
 //
-//  - TODO Call vs Notification
+//   - TODO Call vs Notification
 //
-//  - TODO AWS Lambda packaging
+//   - TODO AWS Lambda packaging
 package apps

--- a/goapp/expand/user_action.go
+++ b/goapp/expand/user_action.go
@@ -27,7 +27,7 @@ func userAction() goapp.Bindable {
 			return apps.NewFormResponse(apps.Form{
 				Title: "Example of a user call with expand",
 				Header: fmt.Sprintf("Press OK to submit the following call: %s\n\n", utils.JSONBlock(submit)) +
-					fmt.Sprintf("Note that `\"acting_user_access_token\":\"all\"` is added so that team and channel expansion works without first having to add the bot as the team/channel member."),
+					"Note that `\"acting_user_access_token\":\"all\"` is added so that team and channel expansion works without first having to add the bot as the team/channel member.",
 				Submit: submit,
 			})
 		},

--- a/server/builtin/app.go
+++ b/server/builtin/app.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"runtime/debug"
 
@@ -214,7 +213,7 @@ func (a *builtinApp) Roundtrip(ctx context.Context, _ apps.App, creq apps.CallRe
 				return
 			}
 			err = nil
-			out = ioutil.NopCloser(bytes.NewReader(data))
+			out = io.NopCloser(bytes.NewReader(data))
 		}
 	}(r.Log)
 
@@ -223,7 +222,7 @@ func (a *builtinApp) Roundtrip(ctx context.Context, _ apps.App, creq apps.CallRe
 		if err != nil {
 			return nil, err
 		}
-		return ioutil.NopCloser(bytes.NewReader(data)), nil
+		return io.NopCloser(bytes.NewReader(data)), nil
 	}
 
 	h, ok := a.router[creq.Path]

--- a/server/builtin/install_consent.go
+++ b/server/builtin/install_consent.go
@@ -196,7 +196,7 @@ func (a *builtinApp) newInstallConsentForm(m apps.Manifest, creq apps.CallReques
 	}
 }
 
-func (a *builtinApp) stateAsManifest(r *incoming.Request, creq apps.CallRequest) (*apps.Manifest, error) {
+func (a *builtinApp) stateAsManifest(_ *incoming.Request, creq apps.CallRequest) (*apps.Manifest, error) {
 	id, ok := creq.State.(string)
 	if !ok {
 		return nil, errors.New("no app ID in State, don't know what to install")

--- a/server/builtin/list.go
+++ b/server/builtin/list.go
@@ -85,13 +85,11 @@ func (a *builtinApp) list(r *incoming.Request, creq apps.CallRequest) apps.CallR
 				ID:    "command.list.submit.status.disabled",
 				Other: "Installed, Disabled",
 			})
-		} else {
-			if !reachable[app.AppID] {
-				status = a.conf.I18N().LocalizeDefaultMessage(loc, &i18n.Message{
-					ID:    "command.list.submit.status.unreachable",
-					Other: "Installed, **Unreachable**",
-				})
-			}
+		} else if !reachable[app.AppID] {
+			status = a.conf.I18N().LocalizeDefaultMessage(loc, &i18n.Message{
+				ID:    "command.list.submit.status.unreachable",
+				Other: "Installed, **Unreachable**",
+			})
 		}
 
 		version := string(app.Version)

--- a/server/httpin/admin.go
+++ b/server/httpin/admin.go
@@ -15,17 +15,22 @@ import (
 // manifest store, making the App installable. The resulting listed manifest
 // will combine the deployment information from the prior listing, and the new
 // manifests as follows:
-//   1. The "core" manifest (except Deploy) is updated to the new values.
-//   2. Deploy types from the previously listed manifest are updated from the new manifest, or preserved.
-//   3. Deploy types specified in "add_deploys" are copied from the new manifest.
-//   4. "remove"
-//   Path: /api/v1/add-listed-app
-//   Method: POST
-//   Input: JSON{
-//      Manifest...
-//      "add_deploys": []string e.g. ["aws_lambda","http"]
-//      "remove_deploys": []string e.g. ["aws_lambda","http"]
-//   Output: The updated listing manifest
+//
+//  1. The "core" manifest (except Deploy) is updated to the new values.
+//  2. Deploy types from the previously listed manifest are updated from the new manifest, or preserved.
+//  3. Deploy types specified in "add_deploys" are copied from the new manifest.
+//  4. "remove"
+//
+// _
+//
+//	Path: /api/v1/add-listed-app
+//	Method: POST
+//	Input: JSON{
+//		Manifest...
+//		"add_deploys": []string e.g. ["aws_lambda","http"]
+//		"remove_deploys": []string e.g. ["aws_lambda","http"]
+//	}
+//	Output: The updated listing manifest
 func (s *Service) UpdateAppListing(r *incoming.Request, w http.ResponseWriter, req *http.Request) {
 	var err error
 	defer func() { httputils.WriteErrorIfNeeded(w, err) }()
@@ -45,10 +50,11 @@ func (s *Service) UpdateAppListing(r *incoming.Request, w http.ResponseWriter, r
 
 // InstallApp installs an App that is already deployed, either locally or in the
 // Marketplace (if applicable).
-//   Path: /api/v1/install-app
-//   Method: POST
-//   Input: JSON {app_id, deploy_type}
-//   Output: JSON, unsanitized App record
+//
+//	Path: /api/v1/install-app
+//	Method: POST
+//	Input: JSON {app_id, deploy_type}
+//	Output: JSON, unsanitized App record
 func (s *Service) InstallApp(r *incoming.Request, w http.ResponseWriter, req *http.Request) {
 	var err error
 	defer func() { httputils.WriteErrorIfNeeded(w, err) }()
@@ -66,10 +72,11 @@ func (s *Service) InstallApp(r *incoming.Request, w http.ResponseWriter, req *ht
 }
 
 // EnableApp enables an App .
-//   Path: /api/v1/enable-app
-//   Method: POST
-//   Input: JSON {app_id}
-//   Output: none
+//
+//	Path: /api/v1/enable-app
+//	Method: POST
+//	Input: JSON {app_id}
+//	Output: none
 func (s *Service) EnableApp(r *incoming.Request, w http.ResponseWriter, req *http.Request) {
 	var err error
 	defer func() { httputils.WriteErrorIfNeeded(w, err) }()
@@ -87,10 +94,11 @@ func (s *Service) EnableApp(r *incoming.Request, w http.ResponseWriter, req *htt
 }
 
 // DisableApp disables an App .
-//   Path: /api/v1/disable-app
-//   Method: POST
-//   Input: JSON {app_id}
-//   Output: JSON, unsanitized App record
+//
+//	Path: /api/v1/disable-app
+//	Method: POST
+//	Input: JSON {app_id}
+//	Output: JSON, unsanitized App record
 func (s *Service) DisableApp(r *incoming.Request, w http.ResponseWriter, req *http.Request) {
 	var err error
 	defer func() { httputils.WriteErrorIfNeeded(w, err) }()
@@ -108,10 +116,11 @@ func (s *Service) DisableApp(r *incoming.Request, w http.ResponseWriter, req *ht
 }
 
 // UninstallApp uninstalls an App .
-//   Path: /api/v1/uninstall-app
-//   Method: POST
-//   Input: JSON {app_id}
-//   Output: None
+//
+//	Path: /api/v1/uninstall-app
+//	Method: POST
+//	Input: JSON {app_id}
+//	Output: None
 func (s *Service) UninstallApp(r *incoming.Request, w http.ResponseWriter, req *http.Request) {
 	var err error
 	defer func() { httputils.WriteErrorIfNeeded(w, err) }()
@@ -128,10 +137,11 @@ func (s *Service) UninstallApp(r *incoming.Request, w http.ResponseWriter, req *
 
 // GetApp returns the App's record. If requestor is a system administrator, the
 // raw record with secrets is returned, otherwise the output is sanitized.
-//   Path: /apps/{AppID}
-//   Method: GET
-//   Input: none
-//   Output: App
+//
+//	Path: /apps/{AppID}
+//	Method: GET
+//	Input: none
+//	Output: App
 func (s *Service) GetApp(r *incoming.Request, w http.ResponseWriter, req *http.Request) {
 	var err error
 	defer func() { httputils.WriteErrorIfNeeded(w, err) }()

--- a/server/httpin/bindings.go
+++ b/server/httpin/bindings.go
@@ -10,10 +10,11 @@ import (
 )
 
 // GetBindings returns combined bindings for all Apps.
-//   Path: /api/v1/bindings
-//   Method: GET
-//   Input: none
-//   Output: []Binding
+//
+//	Path: /api/v1/bindings
+//	Method: GET
+//	Input: none
+//	Output: []Binding
 func (s *Service) GetBindings(r *incoming.Request, w http.ResponseWriter, req *http.Request) {
 	q := req.URL.Query()
 	bindings, err := s.Proxy.GetBindings(r, apps.Context{

--- a/server/httpin/call.go
+++ b/server/httpin/call.go
@@ -12,10 +12,11 @@ import (
 )
 
 // Call handles a call request for an App.
-//   Path: /api/v1/call
-//   Method: POST
-//   Input: CallRequest
-//   Output: CallResponse
+//
+//	Path: /api/v1/call
+//	Method: POST
+//	Input: CallRequest
+//	Output: CallResponse
 func (s *Service) Call(r *incoming.Request, w http.ResponseWriter, req *http.Request) {
 	creq, err := apps.CallRequestFromJSONReader(req.Body)
 	if err != nil {

--- a/server/httpin/get_ids.go
+++ b/server/httpin/get_ids.go
@@ -8,10 +8,11 @@ import (
 )
 
 // GetBotIDs returns the list of all Apps' bot user IDs.
-//   Path: /api/v1/bot-ids
-//   Method: GET
-//   Input: none
-//   Output: []string - the list of Bot user IDs for all installed Apps.
+//
+//	Path: /api/v1/bot-ids
+//	Method: GET
+//	Input: none
+//	Output: []string - the list of Bot user IDs for all installed Apps.
 func (s *Service) GetBotIDs(r *incoming.Request, w http.ResponseWriter, req *http.Request) {
 	apps := s.Proxy.GetInstalledApps()
 	ids := []string{}
@@ -25,10 +26,11 @@ func (s *Service) GetBotIDs(r *incoming.Request, w http.ResponseWriter, req *htt
 }
 
 // GetBindings returns combined bindings for all Apps.
-//   Path: /api/v1/get-oauth-app-ids
-//   Method: GET
-//   Input: none
-//   Output: []string - the list of OAuth ClientIDs for all installed Apps.
+//
+//	Path: /api/v1/get-oauth-app-ids
+//	Method: GET
+//	Input: none
+//	Output: []string - the list of OAuth ClientIDs for all installed Apps.
 func (s *Service) GetOAuthAppIDs(r *incoming.Request, w http.ResponseWriter, req *http.Request) {
 	apps := s.Proxy.GetInstalledApps()
 	ids := []string{}

--- a/server/httpin/kv.go
+++ b/server/httpin/kv.go
@@ -15,10 +15,11 @@ const (
 )
 
 // KVGet returns a value stored by the App in the KV store.
-//   Path: /api/v1/kv/[{prefix}/]{key}
-//   Method: GET
-//   Input: none
-//   Output: a JSON object
+//
+//	Path: /api/v1/kv/[{prefix}/]{key}
+//	Method: GET
+//	Input: none
+//	Output: a JSON object
 func (s *Service) KVGet(r *incoming.Request, w http.ResponseWriter, req *http.Request) {
 	id := mux.Vars(req)["key"]
 	prefix := mux.Vars(req)["prefix"]
@@ -33,11 +34,12 @@ func (s *Service) KVGet(r *incoming.Request, w http.ResponseWriter, req *http.Re
 }
 
 // KVPut stores an App-provided JSON document in the KV store.
-//   Path: /api/v1/kv/[{prefix}/]{key}
-//   Methods: POST, PUT
-//   Output: a JSON object
-//   Output:
-//     changed: set to true if the key value was changed.
+//
+//	Path: /api/v1/kv/[{prefix}/]{key}
+//	Methods: POST, PUT
+//	Output: a JSON object
+//	Output:
+//	  changed: set to true if the key value was changed.
 func (s *Service) KVPut(r *incoming.Request, w http.ResponseWriter, req *http.Request) {
 	id := mux.Vars(req)["key"]
 	prefix := mux.Vars(req)["prefix"]
@@ -58,10 +60,11 @@ func (s *Service) KVPut(r *incoming.Request, w http.ResponseWriter, req *http.Re
 }
 
 // KVDelete removes a (App-specific) value from the KV store.
-//   Path: /api/v1/kv/[{prefix}/]{key}
-//   Methods: DELETE
-//   Input: none
-//   Output: none
+//
+//	Path: /api/v1/kv/[{prefix}/]{key}
+//	Methods: DELETE
+//	Input: none
+//	Output: none
 func (s *Service) KVDelete(r *incoming.Request, w http.ResponseWriter, req *http.Request) {
 	id := mux.Vars(req)["key"]
 	prefix := mux.Vars(req)["prefix"]

--- a/server/httpin/service.go
+++ b/server/httpin/service.go
@@ -128,9 +128,11 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	if s, ok := mux.Vars(req)[AppIDVar]; ok {
 		r = r.WithDestination(apps.AppID(s))
 	}
-	var cancel context.CancelFunc
-	r = r.WithTimeout(config.RequestTimeout, &cancel)
+
+	ctx, cancel := context.WithTimeout(context.Background(), config.RequestTimeout)
 	defer cancel()
+	r = r.WithCtx(ctx)
+
 	r.Log = r.Log.With(
 		"path", req.URL.Path,
 	)

--- a/server/httpin/subscribe.go
+++ b/server/httpin/subscribe.go
@@ -10,10 +10,11 @@ import (
 )
 
 // GetSubscriptions returns a users current list of subscriptions.
-//   Path: /api/v1/subscribe
-//   Method: GET
-//   Input: None
-//   Output: []Subscription
+//
+//	Path: /api/v1/subscribe
+//	Method: GET
+//	Input: None
+//	Output: []Subscription
 func (s *Service) GetSubscriptions(r *incoming.Request, w http.ResponseWriter, req *http.Request) {
 	subs, err := s.AppServices.GetSubscriptions(r)
 	if err != nil {
@@ -24,10 +25,11 @@ func (s *Service) GetSubscriptions(r *incoming.Request, w http.ResponseWriter, r
 }
 
 // Subscribe starts or updates an App subscription to Mattermost events.
-//   Path: /api/v1/subscribe
-//   Method: POST
-//   Input: Subscription
-//   Output: None
+//
+//	Path: /api/v1/subscribe
+//	Method: POST
+//	Input: Subscription
+//	Output: None
 func (s *Service) Subscribe(r *incoming.Request, w http.ResponseWriter, req *http.Request) {
 	var sub apps.Subscription
 	if err := json.NewDecoder(req.Body).Decode(&sub); err != nil {
@@ -41,10 +43,11 @@ func (s *Service) Subscribe(r *incoming.Request, w http.ResponseWriter, req *htt
 }
 
 // Unsubscribe removes an App's subscription to Mattermost events.
-//   Path: /api/v1/unsubscribe
-//   Method: POST
-//   Input: Subscription
-//   Output: None
+//
+//	Path: /api/v1/unsubscribe
+//	Method: POST
+//	Input: Subscription
+//	Output: None
 func (s *Service) Unsubscribe(r *incoming.Request, w http.ResponseWriter, req *http.Request) {
 	var e apps.Event
 	if err := json.NewDecoder(req.Body).Decode(&e); err != nil {

--- a/server/incoming/request.go
+++ b/server/incoming/request.go
@@ -2,7 +2,6 @@ package incoming
 
 import (
 	"context"
-	"time"
 
 	pluginapi "github.com/mattermost/mattermost-plugin-api"
 	"github.com/mattermost/mattermost-server/v6/model"
@@ -64,19 +63,6 @@ func (r *Request) Ctx() context.Context {
 func (r *Request) WithCtx(ctx context.Context) *Request {
 	r = r.Clone()
 	r.ctx = ctx
-	return r
-}
-
-func (r *Request) WithTimeout(timeout time.Duration, cancelFunc *context.CancelFunc) *Request {
-	if timeout == 0 {
-		return r
-	}
-	r = r.Clone()
-	ctx, f := context.WithTimeout(r.Ctx(), timeout)
-	r.ctx = ctx
-	if cancelFunc != nil {
-		*cancelFunc = f
-	}
 	return r
 }
 

--- a/server/proxy/expand.go
+++ b/server/proxy/expand.go
@@ -427,10 +427,7 @@ func (e *expander) ensureClient() error {
 
 	switch {
 	case app.DeployType == apps.DeployBuiltin:
-		client, err = mmclient.NewRPCClient(e.proxy.conf.MattermostAPI()), nil
-		if err != nil {
-			return errors.Wrap(err, "failed to get an RPC client")
-		}
+		client = mmclient.NewRPCClient(e.proxy.conf.MattermostAPI())
 
 	case app.GrantedPermissions.Contains(apps.PermissionActAsUser) && e.r.ActingUserID() != "":
 		token, err := e.getActingUserAccessToken()

--- a/server/proxy/form.go
+++ b/server/proxy/form.go
@@ -27,7 +27,7 @@ func cleanForm(in apps.Form, conf config.Config, appID apps.AppID) (apps.Form, e
 	if in.Icon != "" {
 		icon, err := normalizeStaticPath(conf, appID, in.Icon)
 		if err != nil {
-			problems = multierror.Append(problems, errors.Wrap(err, "invalid icon path in form."))
+			problems = multierror.Append(problems, errors.Wrap(err, "invalid icon path in form"))
 			out.Icon = ""
 		} else {
 			out.Icon = icon

--- a/server/proxy/install.go
+++ b/server/proxy/install.go
@@ -22,7 +22,7 @@ import (
 )
 
 // InstallApp installs an App.
-//  - cc is the Context that will be passed down to the App's OnInstall callback.
+//   - cc is the Context that will be passed down to the App's OnInstall callback.
 func (p *Proxy) InstallApp(r *incoming.Request, cc apps.Context, appID apps.AppID, deployType apps.DeployType, trusted bool, secret string) (*apps.App, string, error) {
 	if err := r.Check(
 		r.RequireActingUser,

--- a/server/store/service.go
+++ b/server/store/service.go
@@ -24,11 +24,11 @@ import (
 // format. Hashkeys have the following format (see service_test.go#TestHashkey
 // for examples):
 //
-//  - global prefix of ".X" where X is exactly 1 byte (2 bytes)
-//  - bot user ID (26 bytes)
-//  - app-specific prefix, limited to 2 non-space ASCII characters, right-filled
-//   with ' ' to 2 bytes.
-//  - app-specific key hash: 16 bytes, ascii85 (20 bytes)
+//   - global prefix of ".X" where X is exactly 1 byte (2 bytes)
+//   - bot user ID (26 bytes)
+//   - app-specific prefix, limited to 2 non-space ASCII characters, right-filled
+//     with ' ' to 2 bytes.
+//   - app-specific key hash: 16 bytes, ascii85 (20 bytes)
 //
 // All other keys must start with an ASCII letter. '.' is usually used as the
 // terminator since it is not used in the base64 representation.

--- a/test/app/main.go
+++ b/test/app/main.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/dgrijalva/jwt-go"
 	"github.com/gorilla/mux"
@@ -79,10 +80,16 @@ func main() {
 		err := errors.Errorf("path not found: %s", r.URL.Path)
 		_ = httputils.WriteJSON(w, apps.NewErrorResponse(err))
 	})
-	http.Handle("/", r)
+
+	server := &http.Server{
+		Addr:              listen,
+		ReadHeaderTimeout: 3 * time.Second,
+		WriteTimeout:      5 * time.Second,
+		Handler:           r,
+	}
 
 	Log.Infof("test app started, listening on port %s, manifest at %s/manifest.json", portStr, AppManifest.Deploy.HTTP.RootURL)
-	panic(http.ListenAndServe(listen, nil))
+	panic(server.ListenAndServe())
 }
 
 func handle(f callHandler) http.HandlerFunc {

--- a/test/app/root.go
+++ b/test/app/root.go
@@ -8,10 +8,12 @@ import (
 )
 
 // appManifestData is preloaded with the Mattermost App manifest.
+//
 //go:embed manifest.json
 var appManifestData []byte
 
 // StaticFS is preloaded with the contents of the ./static directory.
+//
 //go:embed static
 var StaticFS embed.FS
 

--- a/test/hello-world/hello.go
+++ b/test/hello-world/hello.go
@@ -4,8 +4,8 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -131,9 +131,15 @@ func main() {
 	http.HandleFunc("/send", Send)
 
 	addr := ":4000" // matches manifest.json
+	server := &http.Server{
+		Addr:              addr,
+		ReadHeaderTimeout: 3 * time.Second,
+		WriteTimeout:      5 * time.Second,
+	}
+
 	fmt.Println("Listening on", addr)
 	fmt.Println("Use '/apps install http http://localhost" + addr + "/manifest.json' to install the app") // matches manifest.json
-	log.Fatal(http.ListenAndServe(addr, nil))
+	panic(server.ListenAndServe())
 }
 
 // Send sends a DM back to the user.
@@ -148,13 +154,13 @@ func Send(w http.ResponseWriter, req *http.Request) {
 	}
 	_, err := appclient.AsBot(c.Context).DM(c.Context.ActingUser.Id, message)
 	if err != nil {
-		_ = httputils.WriteJSON(w, apps.NewErrorResponse(errors.Wrap(err, "Failed to send bot DM.")))
+		_ = httputils.WriteJSON(w, apps.NewErrorResponse(errors.Wrap(err, "Failed to send bot DM")))
 		return
 	}
 
 	_, err = appclient.AsActingUser(c.Context).DM(c.Context.BotUserID, "Hello, bot!")
 	if err != nil {
-		_ = httputils.WriteJSON(w, apps.NewErrorResponse(errors.Wrap(err, "Failed to respond to bot.")))
+		_ = httputils.WriteJSON(w, apps.NewErrorResponse(errors.Wrap(err, "Failed to respond to bot")))
 		return
 	}
 

--- a/test/restapitest/admin.go
+++ b/test/restapitest/admin.go
@@ -16,6 +16,7 @@ import (
 )
 
 // static is preloaded with the contents of the ./static directory.
+//
 //go:embed static
 var static embed.FS
 

--- a/test/restapitest/bindings.go
+++ b/test/restapitest/bindings.go
@@ -24,7 +24,7 @@ type bindingsApp struct {
 	cresp apps.CallResponse
 }
 
-func newBindingsApp(th *Helper, appID apps.AppID, bindExpand *apps.Expand, bindings []apps.Binding) *bindingsApp {
+func newBindingsApp(_ *Helper, appID apps.AppID, bindExpand *apps.Expand, bindings []apps.Binding) *bindingsApp {
 	app := bindingsApp{}
 	app.App = goapp.MakeAppOrPanic(
 		apps.Manifest{

--- a/test/restapitest/clients.go
+++ b/test/restapitest/clients.go
@@ -85,7 +85,7 @@ func (th *Helper) CallWithAppMetadata(appID apps.AppID, creq apps.CallRequest) (
 	}
 
 	resp, err := th.UserClientPP.DoAPIPOST(
-		th.UserClientPP.GetPluginRoute(appclient.AppsPluginName)+appspath.API+appspath.Call, string(b)) // nolint:bodyclose
+		th.UserClientPP.GetPluginRoute(appclient.AppsPluginName)+appspath.API+appspath.Call, string(b))
 	if resp.Body != nil {
 		defer resp.Body.Close()
 	}

--- a/test/restapitest/expand.go
+++ b/test/restapitest/expand.go
@@ -4,8 +4,6 @@
 package restapitest
 
 import (
-	"github.com/mattermost/mattermost-server/v6/model"
-
 	"github.com/mattermost/mattermost-plugin-apps/apps"
 )
 
@@ -27,7 +25,7 @@ func expandEverything(level apps.ExpandLevel) apps.Expand {
 	}
 }
 
-func forExpandClientCombinations(th *Helper, appBotUser *model.User, expandSet []apps.ExpandLevel, except []appClient, runf func(*Helper, apps.ExpandLevel, appClient)) {
+func forExpandClientCombinations(th *Helper, expandSet []apps.ExpandLevel, except []appClient, runf func(*Helper, apps.ExpandLevel, appClient)) {
 	if len(expandSet) == 0 {
 		expandSet = []apps.ExpandLevel{
 			apps.ExpandNone,

--- a/test/restapitest/helper.go
+++ b/test/restapitest/helper.go
@@ -146,13 +146,13 @@ func (th *Helper) verifyExpandedContext(level apps.ExpandLevel, app *apps.App, a
 	require.Equal(th, true, got.DeveloperMode)
 
 	require.NotEmpty(th, got.BotAccessToken)
-	expected.BotAccessToken, got.BotAccessToken = "", ""
+	got.BotAccessToken = ""
 	if level != apps.ExpandAll {
 		require.Empty(th, got.ActingUserAccessToken)
 	} else {
 		require.NotEmpty(th, got.ActingUserAccessToken)
 	}
-	expected.ActingUserAccessToken, got.ActingUserAccessToken = "", ""
+	got.ActingUserAccessToken = ""
 
 	if level == apps.ExpandNone {
 		// make sure nothing else is set.

--- a/test/restapitest/notify.go
+++ b/test/restapitest/notify.go
@@ -119,7 +119,7 @@ func testNotify(th *Helper) {
 		"user_created":        notifyUserCreated(th),
 	} {
 		th.Run(name, func(th *Helper) {
-			forExpandClientCombinations(th, th.LastInstalledBotUser, tc.expandCombinations, tc.except,
+			forExpandClientCombinations(th, tc.expandCombinations, tc.except,
 				func(th *Helper, level apps.ExpandLevel, appclient appClient) {
 					data := apps.ExpandedContext{}
 					if tc.init != nil {

--- a/test/restapitest/notify_bot_joined_channel.go
+++ b/test/restapitest/notify_bot_joined_channel.go
@@ -12,7 +12,7 @@ import (
 // notifyBotJoinsChannel creates a test channel in a new test team. Bot, User
 // and user2 are added as members of the team, and User is added as a member of
 // the channel. Bot is then added to the channel to trigger.
-func notifyBotJoinedChannel(th *Helper) *notifyTestCase {
+func notifyBotJoinedChannel(_ *Helper) *notifyTestCase {
 	return &notifyTestCase{
 		init: func(th *Helper) apps.ExpandedContext {
 			team := th.createTestTeam()

--- a/test/restapitest/notify_bot_joined_team.go
+++ b/test/restapitest/notify_bot_joined_team.go
@@ -11,7 +11,7 @@ import (
 
 // notifyBotJoinsTeam creates a new test team. User is added as a member of the
 // team. Bot is then added to the channel to trigger.
-func notifyBotJoinedTeam(th *Helper) *notifyTestCase {
+func notifyBotJoinedTeam(_ *Helper) *notifyTestCase {
 	return &notifyTestCase{
 		init: func(th *Helper) apps.ExpandedContext {
 			team := th.createTestTeam()

--- a/test/restapitest/notify_bot_left_channel.go
+++ b/test/restapitest/notify_bot_left_channel.go
@@ -12,7 +12,7 @@ import (
 // notifyBotJoinsChannel creates a test channel in a new test team. Bot, User
 // and user2 are added as members of the team, Bot, User are added as a member
 // of the channel. Bot is then removed from the channel to trigger.
-func notifyBotLeftChannel(th *Helper) *notifyTestCase {
+func notifyBotLeftChannel(_ *Helper) *notifyTestCase {
 	return &notifyTestCase{
 		init: func(th *Helper) apps.ExpandedContext {
 			team := th.createTestTeam()

--- a/test/restapitest/notify_bot_left_team.go
+++ b/test/restapitest/notify_bot_left_team.go
@@ -11,7 +11,7 @@ import (
 
 // notifyBotLeftTeam creates a new test team. User and Bot are added as members of the
 // team. Bot is then removed from the team to trigger.
-func notifyBotLeftTeam(th *Helper) *notifyTestCase {
+func notifyBotLeftTeam(_ *Helper) *notifyTestCase {
 	return &notifyTestCase{
 		init: func(th *Helper) apps.ExpandedContext {
 			data := apps.ExpandedContext{

--- a/test/restapitest/notify_user_left_channel.go
+++ b/test/restapitest/notify_user_left_channel.go
@@ -12,7 +12,7 @@ import (
 // notifyUserJoinsChannel creates a test channel in a new test team. Bot, user
 // and user2 are added as members of the team, and of the channel. User2 is then
 // removed from the channel to trigger.
-func notifyUserLeftChannel(th *Helper) *notifyTestCase {
+func notifyUserLeftChannel(_ *Helper) *notifyTestCase {
 	return &notifyTestCase{
 		init: func(th *Helper) apps.ExpandedContext {
 			data := apps.ExpandedContext{

--- a/test/restapitest/notify_user_left_team.go
+++ b/test/restapitest/notify_user_left_team.go
@@ -11,7 +11,7 @@ import (
 
 // notifyUserLeftTeam creates a new test team. User, user2 and bot are added as members of the
 // team. User2 is then removed from the team to trigger.
-func notifyUserLeftTeam(th *Helper) *notifyTestCase {
+func notifyUserLeftTeam(_ *Helper) *notifyTestCase {
 	return &notifyTestCase{
 		init: func(th *Helper) apps.ExpandedContext {
 			th.Skip(" https://mattermost.atlassian.net/browse/MM-47962")

--- a/test/restapitest/oauth2.go
+++ b/test/restapitest/oauth2.go
@@ -141,9 +141,9 @@ func newOAuth2App(t *testing.T) *goapp.App {
 	app.HandleCall("/err-app-not-json",
 		func(creq goapp.CallRequest) apps.CallResponse {
 			client, _ := params(creq)
-			_, err := client.DoAPIPOST(
+			_, err := client.DoAPIPOST( // nolint:bodyclose
 				client.GetPluginRoute(appclient.AppsPluginName)+appspath.API+appspath.OAuth2App,
-				"test") // nolint:bodyclose
+				"test")
 			return respond("impossible", err)
 		})
 

--- a/upstream/upaws/client_lambda.go
+++ b/upstream/upaws/client_lambda.go
@@ -65,7 +65,7 @@ func (c *client) CreateLambda(archive io.Reader, name, handler, runtime string, 
 
 	fc, err := c.lambda.CreateFunction(createArgs)
 	if err != nil {
-		return "", errors.Wrapf(err, "can't create function, %+v\n", fc)
+		return "", errors.Wrapf(err, "can't create function, %+v", fc)
 	}
 	c.log.Infow("created function", "ARN", *fc.FunctionArn)
 	return ARN(*fc.FunctionArn), nil

--- a/upstream/upaws/provision_app.go
+++ b/upstream/upaws/provision_app.go
@@ -45,20 +45,21 @@ func DeployAppFromFile(c Client, path string, log utils.Logger, params DeployApp
 
 // deployApp gets a release URL parses the release and creates an App in AWS
 // releaseURL should contain a zip with lambda functions' zip files and a `manifest.json`
-//  ~/my_app.zip
-//   |-- manifest.json
-//   |-- static
-//		|-- icon.png
-//		|-- coolFile.txt
-//   |-- my_nodejs_function.zip
-//      |-- index.js
-//      |-- node-modules
-//          |-- async
-//          |-- aws-sdk
-//   |-- my_python_function.zip
-//      |-- lambda_function.py
-//      |-- __pycache__
-//      |-- certifi/
+//
+//	 ~/my_app.zip
+//	  |-- manifest.json
+//	  |-- static
+//			|-- icon.png
+//			|-- coolFile.txt
+//	  |-- my_nodejs_function.zip
+//	     |-- index.js
+//	     |-- node-modules
+//	         |-- async
+//	         |-- aws-sdk
+//	  |-- my_python_function.zip
+//	     |-- lambda_function.py
+//	     |-- __pycache__
+//	     |-- certifi/
 func deployApp(c Client, log utils.Logger, pd *DeployData, params DeployAppParams) (*DeployAppResult, error) {
 	out := DeployAppResult{
 		Manifest: *pd.Manifest,


### PR DESCRIPTION
#### Summary
This PR updates golangci-lint to the version that other plugins use and fixate that version for CI.

It also fixes the newly found linter issues. A lot of them are formatting one due to the go1.18 doc updates.

#### Ticket Link
None

