### PR TITLE
Add webhook secret in context when expanding `app`

### DIFF
--- a/server/proxy/expand.go
+++ b/server/proxy/expand.go
@@ -249,7 +249,6 @@ func (e *expander) expandUser(userPtr **model.User, userID string) expandFunc {
 func (e *expander) expandApp(level apps.ExpandLevel) error {
 	e.ExpandedContext.App = e.app.Strip(level)
 
-	e.ExpandedContext.App.WebhookSecret = ""
 	if level == apps.ExpandAll && e.r.RequireSysadminOrPlugin() == nil {
 		e.ExpandedContext.App.WebhookSecret = e.app.WebhookSecret
 	}

--- a/test/restapitest/helper.go
+++ b/test/restapitest/helper.go
@@ -236,11 +236,12 @@ func (th *Helper) requireEqualApp(level apps.ExpandLevel, asSystemAdmin bool, ex
 	}
 	require.NotNil(th, got, "expected: %+v", expected)
 
-	// Only sysadmins and expansion `all` for app get the webhook secret expanded.
-	if !asSystemAdmin || level != apps.ExpandAll {
+	expected = expected.Strip(level)
+	got = got.Strip(level)
+
+	// Only sysadmins get the webhook secret expanded.
+	if !asSystemAdmin {
 		expected.WebhookSecret = ""
-	} else {
-		require.NotNil(th, expected.WebhookSecret)
 	}
 	require.EqualValues(th, expected, got)
 }

--- a/test/restapitest/helper.go
+++ b/test/restapitest/helper.go
@@ -236,9 +236,11 @@ func (th *Helper) requireEqualApp(level apps.ExpandLevel, asSystemAdmin bool, ex
 	}
 	require.NotNil(th, got, "expected: %+v", expected)
 
-	// Only sysadmins get the webhook secret expanded.
-	if !asSystemAdmin {
+	// Only sysadmins and expansion `all` for app get the webhook secret expanded.
+	if !asSystemAdmin || level != apps.ExpandAll {
 		expected.WebhookSecret = ""
+	} else {
+		require.NotNil(th, expected.WebhookSecret)
 	}
 	require.EqualValues(th, expected, got)
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Add webhook secret when requested for `app` expansion

In latest release [mattermost-plugin-apps-345 (1.1.0)](https://github.com/mattermost/mattermost-plugin-apps/pull/345), there was webhook_secret included in the expanded section of `app` in `context` on `bot_joined_team event`, but now it is not there

