### PR TITLE
[MM-48533] Enable color logs

### DIFF
--- a/cmd/appsctl/aws.go
+++ b/cmd/appsctl/aws.go
@@ -101,7 +101,7 @@ var awsCleanCmd = &cobra.Command{
 
 		accessKeyID := os.Getenv(upaws.AccessEnvVar)
 		if accessKeyID == "" {
-			return errors.Errorf("no AWS access key was provided. Please set %s", upaws.AccessEnvVar)
+			return errors.Errorf("no AWS access key was provided. Please set %s.", upaws.AccessEnvVar)
 		}
 
 		return upaws.CleanAWS(asDeploy, accessKeyID, log)
@@ -314,15 +314,15 @@ with the default initial IAM configuration`,
 func makeTestAWSUpstream() (*upaws.Upstream, error) {
 	region := os.Getenv(upaws.RegionEnvVar)
 	if region == "" {
-		return nil, errors.Errorf("no AWS region was provided. Please set %s", upaws.RegionEnvVar)
+		return nil, errors.Errorf("no AWS region was provided. Please set %s.", upaws.RegionEnvVar)
 	}
 	accessKey := os.Getenv(upaws.AccessEnvVar)
 	if accessKey == "" {
-		return nil, errors.Errorf("no AWS access key was provided. Please set %s", upaws.AccessEnvVar)
+		return nil, errors.Errorf("no AWS access key was provided. Please set %s.", upaws.AccessEnvVar)
 	}
 	secretKey := os.Getenv(upaws.SecretEnvVar)
 	if secretKey == "" {
-		return nil, errors.Errorf("no AWS secret key was provided. Please set %s", upaws.SecretEnvVar)
+		return nil, errors.Errorf("no AWS secret key was provided. Please set %s.", upaws.SecretEnvVar)
 	}
 
 	return upaws.MakeUpstream(accessKey, secretKey, region, upaws.S3BucketName(), log)
@@ -331,15 +331,15 @@ func makeTestAWSUpstream() (*upaws.Upstream, error) {
 func makeDeployAWSClient() (upaws.Client, error) {
 	region := os.Getenv(upaws.RegionEnvVar)
 	if region == "" {
-		return nil, errors.Errorf("no AWS region was provided. Please set %s", upaws.RegionEnvVar)
+		return nil, errors.Errorf("no AWS region was provided. Please set %s.", upaws.RegionEnvVar)
 	}
 	accessKey := os.Getenv(upaws.DeployAccessEnvVar)
 	if accessKey == "" {
-		return nil, errors.Errorf("no AWS access key was provided. Please set %s", upaws.DeployAccessEnvVar)
+		return nil, errors.Errorf("no AWS access key was provided. Please set %s.", upaws.DeployAccessEnvVar)
 	}
 	secretKey := os.Getenv(upaws.DeploySecretEnvVar)
 	if secretKey == "" {
-		return nil, errors.Errorf("no AWS secret key was provided. Please set %s", upaws.DeploySecretEnvVar)
+		return nil, errors.Errorf("no AWS secret key was provided. Please set %s.", upaws.DeploySecretEnvVar)
 	}
 
 	return upaws.MakeClient(accessKey, secretKey, region,

--- a/cmd/appsctl/aws.go
+++ b/cmd/appsctl/aws.go
@@ -101,7 +101,7 @@ var awsCleanCmd = &cobra.Command{
 
 		accessKeyID := os.Getenv(upaws.AccessEnvVar)
 		if accessKeyID == "" {
-			return errors.Errorf("no AWS access key was provided. Please set %s.", upaws.AccessEnvVar)
+			return errors.Errorf("no AWS access key was provided. Please set %s", upaws.AccessEnvVar)
 		}
 
 		return upaws.CleanAWS(asDeploy, accessKeyID, log)
@@ -314,15 +314,15 @@ with the default initial IAM configuration`,
 func makeTestAWSUpstream() (*upaws.Upstream, error) {
 	region := os.Getenv(upaws.RegionEnvVar)
 	if region == "" {
-		return nil, errors.Errorf("no AWS region was provided. Please set %s.", upaws.RegionEnvVar)
+		return nil, errors.Errorf("no AWS region was provided. Please set %s", upaws.RegionEnvVar)
 	}
 	accessKey := os.Getenv(upaws.AccessEnvVar)
 	if accessKey == "" {
-		return nil, errors.Errorf("no AWS access key was provided. Please set %s.", upaws.AccessEnvVar)
+		return nil, errors.Errorf("no AWS access key was provided. Please set %s", upaws.AccessEnvVar)
 	}
 	secretKey := os.Getenv(upaws.SecretEnvVar)
 	if secretKey == "" {
-		return nil, errors.Errorf("no AWS secret key was provided. Please set %s.", upaws.SecretEnvVar)
+		return nil, errors.Errorf("no AWS secret key was provided. Please set %s", upaws.SecretEnvVar)
 	}
 
 	return upaws.MakeUpstream(accessKey, secretKey, region, upaws.S3BucketName(), log)
@@ -331,15 +331,15 @@ func makeTestAWSUpstream() (*upaws.Upstream, error) {
 func makeDeployAWSClient() (upaws.Client, error) {
 	region := os.Getenv(upaws.RegionEnvVar)
 	if region == "" {
-		return nil, errors.Errorf("no AWS region was provided. Please set %s.", upaws.RegionEnvVar)
+		return nil, errors.Errorf("no AWS region was provided. Please set %s", upaws.RegionEnvVar)
 	}
 	accessKey := os.Getenv(upaws.DeployAccessEnvVar)
 	if accessKey == "" {
-		return nil, errors.Errorf("no AWS access key was provided. Please set %s.", upaws.DeployAccessEnvVar)
+		return nil, errors.Errorf("no AWS access key was provided. Please set %s", upaws.DeployAccessEnvVar)
 	}
 	secretKey := os.Getenv(upaws.DeploySecretEnvVar)
 	if secretKey == "" {
-		return nil, errors.Errorf("no AWS secret key was provided. Please set %s.", upaws.DeploySecretEnvVar)
+		return nil, errors.Errorf("no AWS secret key was provided. Please set %s", upaws.DeploySecretEnvVar)
 	}
 
 	return upaws.MakeClient(accessKey, secretKey, region,

--- a/cmd/appsctl/main.go
+++ b/cmd/appsctl/main.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/zap/zapcore"
 
+	root "github.com/mattermost/mattermost-plugin-apps"
 	"github.com/mattermost/mattermost-plugin-apps/utils"
 )
 
@@ -38,8 +39,9 @@ func main() {
 }
 
 var rootCmd = &cobra.Command{
-	Use:   "appsctl",
-	Short: "A tool to manage Mattermost Apps.",
+	Use:     "appsctl",
+	Short:   "A tool to manage Mattermost Apps.",
+	Version: root.Manifest.Version,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		if verbose {
 			log = utils.MustMakeCommandLogger(zapcore.DebugLevel)

--- a/cmd/appsctl/main.go
+++ b/cmd/appsctl/main.go
@@ -34,9 +34,7 @@ func init() {
 }
 
 func main() {
-	if err := rootCmd.Execute(); err != nil {
-		log.WithError(err).Fatalf("command failed")
-	}
+	_ = rootCmd.Execute()
 }
 
 var rootCmd = &cobra.Command{

--- a/utils/logger.go
+++ b/utils/logger.go
@@ -116,6 +116,7 @@ func MustMakeCommandLogger(level zapcore.Level) Logger {
 	encodingConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	encodingConfig.EncodeDuration = zapcore.StringDurationEncoder
 	encodingConfig.EncodeCaller = zapcore.ShortCallerEncoder
+	encodingConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 
 	zconf := zap.Config{
 		Level:            zap.NewAtomicLevelAt(level),


### PR DESCRIPTION
#### Summary
This PR adds two improvments for `appscl`.
1. The log output is now colored.
2. Add a `--version` flag. 
3. Instead of printing a fantal error two times, the error is only printed once, making it more readable.

##### Old
```bash
$ go run . aws clean
Error: no AWS access key was provided. Please set MM_APPS_DEPLOY_AWS_ACCESS_KEY
Usage:
  appsctl aws clean [flags]

Flags:
  -h, --help   help for clean

Global Flags:
  -q, --quiet     quiet (errors only) output
  -v, --verbose   verbose (debug) output

2022-11-21T16:54:35.336+0100	FATAL	appsctl/main.go:38	command failed	{"error": "no AWS access key was provided. Please set MM_APPS_DEPLOY_AWS_ACCESS_KEY"}
main.main
	/home/bschumacher/src/mattermost/plugins/apps/cmd/appsctl/main.go:38
runtime.main
	/usr/local/go/src/runtime/proc.go:250
exit status 1
```

##### New
```bash
$ go run . aws clean
Error: no AWS access key was provided. Please set MM_APPS_DEPLOY_AWS_ACCESS_KEY
Usage:
  appsctl aws clean [flags]

Flags:
  -h, --help   help for clean

Global Flags:
  -q, --quiet     quiet (errors only) output
  -v, --verbose   verbose (debug) output
```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48533