### PR TITLE
Allow expand "summary" for oauth2_user and oauth2_app

### DIFF
--- a/server/proxy/expand.go
+++ b/server/proxy/expand.go
@@ -93,14 +93,12 @@ func (e *expander) expand(expand *apps.Expand) (*apps.Context, error) {
 		f              expandFunc
 		requestedLevel apps.ExpandLevel
 		expandableAs   []apps.ExpandLevel
-		err            error
 	}{
 		{
 			name:           "acting_user_access_token",
 			requestedLevel: expand.ActingUserAccessToken,
 			f:              e.expandActingUserAccessToken,
-			expandableAs:   []apps.ExpandLevel{apps.ExpandAll},
-			err:            utils.NewInvalidError(`invalid expand: "acting_user_access_token" must be "all" or empty`),
+			expandableAs:   []apps.ExpandLevel{apps.ExpandAll, apps.ExpandSummary},
 		}, {
 			name:           "acting_user",
 			requestedLevel: expand.ActingUser,
@@ -131,14 +129,12 @@ func (e *expander) expand(expand *apps.Expand) (*apps.Context, error) {
 			name:           "oauth2_app",
 			requestedLevel: expand.OAuth2App,
 			f:              e.expandOAuth2App,
-			expandableAs:   []apps.ExpandLevel{apps.ExpandAll},
-			err:            utils.NewInvalidError(`invalid expand: "oauth2_app" must be "all" or empty`),
+			expandableAs:   []apps.ExpandLevel{apps.ExpandSummary, apps.ExpandAll},
 		}, {
 			name:           "oauth2_user",
 			requestedLevel: expand.OAuth2User,
 			f:              e.expandOAuth2User,
-			expandableAs:   []apps.ExpandLevel{apps.ExpandAll},
-			err:            utils.NewInvalidError(`invalid expand: "oauth2_user" must be "all" or empty`),
+			expandableAs:   []apps.ExpandLevel{apps.ExpandSummary apps.ExpandAll},
 		}, {
 			name:           "post",
 			requestedLevel: expand.Post,


### PR DESCRIPTION
#### Summary

There is a breaking change in https://github.com/mattermost/mattermost-plugin-apps/pull/336, where we stopped allowing expand `summary` for some expandable objects. Some apps being developed were using this, and the apps are now breaking from this change. Note that this information is not documented here https://developers.mattermost.com/integrate/apps/structure/call-metadata/#expand-levels, so there's not a standard to adhere to, but we should try not to introduce changes that could break existing apps.

This PR makes it so the `oauth2_app` and `oauth2_user` contexts accept the `summary` expand level

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-apps/issues/396

