### PR TITLE
Include JWT secret in test app startup message

### DIFF
--- a/test/app/main.go
+++ b/test/app/main.go
@@ -88,7 +88,7 @@ func main() {
 		Handler:           r,
 	}
 
-	Log.Infof("test app started, listening on port %s, manifest at %s/manifest.json", portStr, AppManifest.Deploy.HTTP.RootURL)
+	Log.Infof("test app started, listening on port %s, manifest at %s/manifest.json. Use %s as the JWT secret.", portStr, AppManifest.Deploy.HTTP.RootURL, AppSecret)
 	panic(server.ListenAndServe())
 }
 


### PR DESCRIPTION
#### Summary
That should make it easier for people to find the secret and serves as a reminder to set it.

#### Ticket Link
Fixes #392
