### PR TITLE
Test app - Add num_bindings command to set number of bindings in different locations

### DIFF
--- a/test/app/channel_header.go
+++ b/test/app/channel_header.go
@@ -15,5 +15,9 @@ func channelHeaderBindings(_ apps.Context) []apps.Binding {
 		out = append(out, invalidFormBindings...)
 	}
 
-	return out
+	if numChannelHeaderBindings < 0 {
+		return out
+	}
+
+	return out[0:numChannelHeaderBindings]
 }

--- a/test/app/command.go
+++ b/test/app/command.go
@@ -13,12 +13,50 @@ func commandBindings(cc apps.Context) []apps.Binding {
 			formCommandBinding(cc),
 			subscriptionCommandBinding("subscribe", Subscribe),
 			subscriptionCommandBinding("unsubscribe", Unsubscribe),
-
+			numBindingsCommandBinding(cc),
 			testCommandBinding(cc),
 		},
 	}
 
 	return []apps.Binding{b}
+}
+
+func numBindingsCommandBinding(cc apps.Context) apps.Binding {
+	return apps.Binding{
+		Label:       "num_bindings",
+		Description: "Choose how many bindings to show in different locations. Provide -1 to use the default options.",
+		Icon:        "icon.png",
+		Form: &apps.Form{
+			Submit: apps.NewCall(NumBindingsPath),
+			Fields: []apps.Field{
+				{
+					Name:                 "location",
+					Type:                 apps.FieldTypeStaticSelect,
+					Description:          "Location to change",
+					IsRequired:           true,
+					AutocompletePosition: 1,
+					SelectStaticOptions: []apps.SelectOption{
+						{
+							Label: "post_menu",
+							Value: "post_menu",
+						},
+						{
+							Label: "channel_header",
+							Value: "channel_header",
+						},
+					},
+				},
+				{
+					Name:                 "number",
+					Type:                 apps.FieldTypeText,
+					TextSubtype:          apps.TextFieldSubtypeNumber,
+					Description:          "Number of bindings to show",
+					IsRequired:           true,
+					AutocompletePosition: 2,
+				},
+			},
+		},
+	}
 }
 
 func testCommandBinding(cc apps.Context) apps.Binding {

--- a/test/app/command.go
+++ b/test/app/command.go
@@ -21,7 +21,7 @@ func commandBindings(cc apps.Context) []apps.Binding {
 	return []apps.Binding{b}
 }
 
-func numBindingsCommandBinding(cc apps.Context) apps.Binding {
+func numBindingsCommandBinding(_ apps.Context) apps.Binding {
 	return apps.Binding{
 		Label:       "num_bindings",
 		Description: "Choose how many bindings to show in different locations. Provide -1 to use the default options.",

--- a/test/app/const.go
+++ b/test/app/const.go
@@ -8,9 +8,10 @@ const (
 	NotifyPath   = "/notify"
 
 	// Commands
-	CreateEmbedded = "/create-embedded"
-	Subscribe      = "/subscribe"
-	Unsubscribe    = "/unsubscribe"
+	CreateEmbedded  = "/create-embedded"
+	Subscribe       = "/subscribe"
+	Unsubscribe     = "/unsubscribe"
+	NumBindingsPath = "/num_bindings"
 
 	// Submit responses
 	OK               = "/ok"

--- a/test/app/main.go
+++ b/test/app/main.go
@@ -74,6 +74,7 @@ func main() {
 	initHTTPLookup(r)
 	initHTTPNavigate(r)
 	initHTTPOK(r)
+	initNumBindingsCommand(r)
 	initHTTPSubscriptions(r)
 
 	r.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/test/app/num_bindings.go
+++ b/test/app/num_bindings.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+
+	"github.com/mattermost/mattermost-plugin-apps/apps"
+)
+
+var numPostMenuBindings int64 = -1
+var numChannelHeaderBindings int64 = -1
+
+func initNumBindingsCommand(r *mux.Router) {
+	handleCall(r, NumBindingsPath, handleNumBindingsCommand)
+}
+
+func handleNumBindingsCommand(creq *apps.CallRequest) apps.CallResponse {
+	location := creq.GetValue("location", "post_menu")
+	numStr := creq.GetValue("number", "-1")
+
+	num, _ := strconv.ParseInt(numStr, 10, 32)
+
+	switch location {
+	case "post_menu":
+		numPostMenuBindings = num
+	case "channel_header":
+		numChannelHeaderBindings = num
+	default:
+		return apps.NewErrorResponse(errors.Errorf("unsupported location %s", location))
+	}
+
+	return apps.NewTextResponse(fmt.Sprintf("changed %s to %d", location, num))
+}

--- a/test/app/post_menu.go
+++ b/test/app/post_menu.go
@@ -15,5 +15,9 @@ func postMenuBindings(_ apps.Context) []apps.Binding {
 		out = append(out, invalidFormBindings...)
 	}
 
-	return out
+	if numPostMenuBindings < 0 {
+		return out
+	}
+
+	return out[0:numPostMenuBindings]
 }


### PR DESCRIPTION
#### Summary

This PR serves as a tool to test the functionality of the client-side functionality of the App framework. It adds a command `/test num_bindings (location) (number)` that allows you to set the number of bindings like so:

- `/test num_bindings post_menu 2` - two items in the post menu
- `/test num_bindings channel_header 0` - no items in the channel header / Apps bar
- `/test num_bindings channel_header -1` - normal set of test bindings

#### Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-apps/issues/401