### PR TITLE
Include caller in logs

### DIFF
--- a/server/httpin/service.go
+++ b/server/httpin/service.go
@@ -161,6 +161,6 @@ func (s *Service) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	s.handlerFunc(r, w, req)
 
 	if s.Config.Get().DeveloperMode {
-		r.Log.Debugf("HTTP")
+		r.Log.Debugf("Handled HTTP request")
 	}
 }

--- a/server/incoming/request.go
+++ b/server/incoming/request.go
@@ -88,7 +88,9 @@ func (r *Request) WithSessionID(sessionID string) *Request {
 
 func (r *Request) WithSourcePluginID(pluginID string) *Request {
 	r = r.Clone()
-	r.Log = r.Log.With("source_plugin_id", pluginID)
+	if pluginID != "" {
+		r.Log = r.Log.With("source_plugin_id", pluginID)
+	}
 	r.sourcePluginID = pluginID
 	return r
 }

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -54,7 +54,7 @@ func TestOnActivate(t *testing.T) {
 		SkuShortName: "professional",
 	})
 
-	expectLog(testAPI, "LogDebug", 13)
+	expectLog(testAPI, "LogDebug", 15)
 	expectLog(testAPI, "LogInfo", 5)
 	expectLog(testAPI, "LogError", 3)
 


### PR DESCRIPTION
#### Summary
12b7e8878c4bd61c21c7f87f945b9c2ac77b649a add callers to the both the file logger. and the channel logger

![Screenshot from 2022-12-07 14-09-10](https://user-images.githubusercontent.com/16541325/206187619-5f9fc26e-ad9a-41a3-8552-98c1de3542b0.png)

```
{"timestamp":"2022-12-07 14:09:06.564 +01:00","level":"debug","msg":"Handled HTTP request","caller":"app/plugin_api.go:970","plugin_id":"com.mattermost.apps","request_id":"t51n6ercg3y78bqshyuj1d559r","path":"/api/v1/bindings","plugin_caller":"server/httpin/service.go:164","from_user_id":"78r48k3iy3b8bxmzfqzsbdnhra"}
```


11f0b7e5acfd317c475d522f43d4bd04c80df01f ensures that `source_plugin_id` is only added if it's not empty, which is most of the time. This make the log messages easier to read.

479a20b22f1df7dee74caa6eb7af0f79c0fd9f70 changes a log message to make it more readable.

#### Ticket Link
Follow up on https://github.com/mattermost/mattermost-plugin-apps/pull/394
