### PR TITLE
[MM-49164] Include apps that can be deployed as plugins but aren't in Marketplace response

### DIFF
--- a/server/httpin/admin.go
+++ b/server/httpin/admin.go
@@ -3,6 +3,7 @@ package httpin
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 
 	"github.com/mattermost/mattermost-plugin-apps/apps"
 	"github.com/mattermost/mattermost-plugin-apps/apps/appclient"
@@ -155,7 +156,7 @@ func (s *Service) GetApp(r *incoming.Request, w http.ResponseWriter, req *http.R
 
 func (s *Service) GetMarketplace(r *incoming.Request, w http.ResponseWriter, req *http.Request) {
 	filter := req.URL.Query().Get("filter")
-	includePlugins := req.URL.Query().Get("include_plugins") != ""
+	includePlugins, _ := strconv.ParseBool(req.URL.Query().Get("include_plugins"))
 
 	result := s.Proxy.GetListedApps(filter, includePlugins)
 	_ = httputils.WriteJSON(w, result)

--- a/server/proxy/list.go
+++ b/server/proxy/list.go
@@ -117,10 +117,6 @@ func (p *Proxy) GetListedApps(filter string, includePluginApps bool) []apps.List
 			continue
 		}
 
-		if !includePluginApps && m.Contains(apps.DeployPlugin) {
-			continue
-		}
-
 		marketApp := apps.ListedApp{
 			Manifest: m,
 		}
@@ -130,6 +126,19 @@ func (p *Proxy) GetListedApps(filter string, includePluginApps bool) []apps.List
 		}
 
 		app, _ := p.store.App.Get(m.AppID)
+
+		if !includePluginApps {
+			// Filter out if installed as plugin
+			if app != nil && app.DeployType == apps.DeployPlugin {
+				continue
+			}
+
+			// Filter out if not installed and only deployable as plugin
+			if app == nil && len(m.DeployTypes()) == 1 && m.DeployTypes()[0] == apps.DeployPlugin {
+				continue
+			}
+		}
+
 		if app != nil {
 			marketApp.Installed = true
 			marketApp.Enabled = !app.Disabled


### PR DESCRIPTION
#### Summary
E.g. the ServiceNow App _can_ be deployed as a plugin, but isn't in Cloud. `api/v1/marketplace?include_plugins=false` should return it.

This PR relaxes the checks around `includePluginApps` to only filter the apps out that are deployed as plugins or can only be deployed as plugins.

#### TODO
- [x] https://github.com/mattermost/mattermost-plugin-apps/blob/71155dd04c7fac09cf0e4ebb2c150a55cd45774d/server/httpin/admin.go#L158 should check for an match to `true`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49164
