### PR TITLE
[MM-49470] Add command to validate AWS bundle

### DIFF
--- a/cmd/appsctl/aws.go
+++ b/cmd/appsctl/aws.go
@@ -38,6 +38,9 @@ func init() {
 	// clean
 	awsCmd.AddCommand(awsCleanCmd)
 
+	// validate
+	awsCmd.AddCommand(awsValidateCmd)
+
 	// test
 	awsCmd.AddCommand(awsTestCmd)
 	awsTestCmd.AddCommand(awsTestLambdaCmd)
@@ -105,6 +108,22 @@ var awsCleanCmd = &cobra.Command{
 		}
 
 		return upaws.CleanAWS(asDeploy, accessKeyID, log)
+	},
+}
+
+var awsValidateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: "Validate that a given bundle is correctly build",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		deployData, err := upaws.GetDeployDataFromFile(args[0], log)
+		if err != nil {
+			return err
+		}
+		log.Infof("Bundle is valid!")
+		log.Debugf("Deploy data: %s\n", utils.Pretty(deployData))
+
+		return nil
 	},
 }
 

--- a/upstream/upaws/provision_app.go
+++ b/upstream/upaws/provision_app.go
@@ -21,6 +21,7 @@ type DeployAppParams struct {
 	InvokePolicyName Name
 	ExecuteRoleName  Name
 	ShouldUpdate     bool
+	DryRun           bool
 	Environment      map[string]string
 }
 


### PR DESCRIPTION
#### Summary
```bash
$ go run ./cmd/appsctl aws validate bundle.zip -v
2023-01-04T02:48:01.966+0100	INFO	upaws/provision_data.go:92	found manifest	{"file": "manifest.json"}
2023-01-04T02:48:01.966+0100	INFO	upaws/provision_data.go:120	found static asset	{"file": "static/google.png"}
2023-01-04T02:48:01.966+0100	INFO	upaws/provision_data.go:120	found static asset	{"file": "static/drive.png"}
2023-01-04T02:48:01.966+0100	INFO	upaws/provision_data.go:104	found lambda function bundle	{"file": "bundle.zip"}
2023-01-04T02:48:01.966+0100	INFO	appsctl/aws.go:123	Bundle is valid!
2023-01-04T02:48:01.966+0100	DEBUG	appsctl/aws.go:124	Deploy data: {
  "static_files": {
    "drive.png": {
      "key": "static/google-drive_1.0.0_app/drive.png"
    },
    "google.png": {
      "key": "static/google-drive_1.0.0_app/google.png"
    }
  },
  "lambda_functions": {
    "bundle": {
      "name": "google-drive_1-0-0_bundle",
      "handler": "bundle/index.handler",
      "runtime": "nodejs16.x"
    }
  },
  "manifest_key": "manifests/google-drive_1.0.0.json"
}
```

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49470