### PR TITLE
[MM-48800] Refresh bindings on activation

### DIFF
--- a/server/plugin.go
+++ b/server/plugin.go
@@ -135,6 +135,7 @@ func (p *Plugin) OnActivate() (err error) {
 	log.Infof("activated")
 
 	p.conf.MattermostAPI().Frontend.PublishWebSocketEvent(config.WebSocketEventPluginEnabled, conf.GetPluginVersionInfo(), &model.WebsocketBroadcast{})
+	p.conf.MattermostAPI().Frontend.PublishWebSocketEvent(config.WebSocketEventRefreshBindings, map[string]interface{}{}, &model.WebsocketBroadcast{})
 
 	return nil
 }

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -62,6 +62,7 @@ func TestOnActivate(t *testing.T) {
 	testAPI.On("RegisterCommand", mock.AnythingOfType("*model.Command")).Return(nil)
 
 	testAPI.On("PublishWebSocketEvent", "plugin_enabled", map[string]interface{}{"version": manifest.Version}, &model.WebsocketBroadcast{})
+	testAPI.On("PublishWebSocketEvent", "refresh_bindings", map[string]interface{}{}, &model.WebsocketBroadcast{})
 
 	err := p.OnActivate()
 	require.NoError(t, err)


### PR DESCRIPTION

#### Summary

Disabling and enabling the apps plugin does make Bindings disappear, so we need to refresh the bindings on activation.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-48800

