### PR TITLE
Add timeout for bindings calls

### DIFF
--- a/server/proxy/bindings.go
+++ b/server/proxy/bindings.go
@@ -12,6 +12,8 @@ import (
 	"github.com/mattermost/mattermost-plugin-apps/server/store"
 )
 
+const bindingsFetchTimeout = 5 * time.Second
+
 func mergeBindings(bb1, bb2 []apps.Binding) []apps.Binding {
 	out := append([]apps.Binding(nil), bb1...)
 
@@ -58,7 +60,10 @@ func (p *Proxy) GetBindings(r *incoming.Request, cc apps.Context) ([]apps.Bindin
 
 	for i := range allApps {
 		go func(app apps.App) {
-			apprequest := r.WithDestination(app.AppID)
+			ctx, done := context.WithTimeout(r.Ctx(), bindingsFetchTimeout)
+			defer done()
+
+			apprequest := r.WithDestination(app.AppID).WithCtx(ctx)
 			res := result{
 				appID: app.AppID,
 			}


### PR DESCRIPTION
#### Summary

In the code below, we fan out the bindings requests to multiple apps. At the end of this anonymous function, we send the result to the channel being used to sync the responses below this block. The problem is that if that line never runs, the channel blocks forever, which results in the "(pending)" requests in the screenshot below.

https://github.com/mattermost/mattermost-plugin-apps/blob/461e9e66bb08cee1effcff459249072ce0c816ff/server/proxy/bindings.go#L59-L70

![image](https://user-images.githubusercontent.com/6913320/214662565-68533ae5-3df3-4fb4-b9d4-6d8efc6056e8.png)

While writing unit tests for the bindings fetch code, I ran into an issue with the test hanging. I had a missing gomock call inside the call stack of the above goroutine function, which caused the test to try to exit, silently unless running the test in verbose mode. This results in the test hanging because it can't bubble up the missing mock call failure outside of the spawned goroutine.

Note that this is a bit unrealistic compared to production, though I have experienced the bindings call hanging in my local environment. Please see [this thread](https://community.mattermost.com/core/pl/ndg1jgjntffibqdxbh1ee63w7r) for more context. I'm not entirely sure what causes that but adding a timeout to the fetch call at least makes it so we can prevent that avenue of issues. We may also want to have a panic recover here, as we want to be 100% sure we send to the channel so the overall bindings request does not hang.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-48543