### PR TITLE
Remove app id for top level bindings

### DIFF
--- a/server/proxy/invoke_bindings.go
+++ b/server/proxy/invoke_bindings.go
@@ -127,7 +127,9 @@ func cleanAppBinding(
 	}
 
 	// Ensure all bindings except the top-level have the AppID set, forcefully.
-	if !fql.IsTop() {
+	if fql.IsTop() {
+		b.AppID = ""
+	} else {
 		b.AppID = app.AppID
 	}
 


### PR DESCRIPTION
#### Summary

This currently isn’t causing any functional issues, though there is an issue where the top level binding coming from an app will contain an app id if the app supplied, whereas it will be blank if none was provided. This inconsistent behavior, depending on if a given app provides that id in its top level bindings, has confused me for some time so I fixed the issue.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-49971