### PR TITLE
[MM-49986] Only show enabled apps for /apps debug bindings

### DIFF
--- a/server/builtin/debug_bindings.go
+++ b/server/builtin/debug_bindings.go
@@ -25,7 +25,7 @@ func (a *builtinApp) debugBindingsCommandBinding(loc *i18n.Localizer) apps.Bindi
 		Form: &apps.Form{
 			Submit: newUserCall(pDebugBindings),
 			Fields: []apps.Field{
-				a.appIDField(LookupInstalledApps, 1, true, loc),
+				a.appIDField(LookupEnabledApps, 1, true, loc),
 			},
 		},
 	}


### PR DESCRIPTION
#### Summary
/apps debug bindings will fail for any disabled app. So disabled apps should not be listed in the auto-completion.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-49986