### PR TITLE
[MM-49992] Propagate errors from /ping

### DIFF
--- a/server/proxy/install.go
+++ b/server/proxy/install.go
@@ -80,7 +80,8 @@ func (p *Proxy) InstallApp(r *incoming.Request, cc apps.Context, appID apps.AppI
 	}
 	r.Log.Debugf("app install flow: updated app configuration")
 
-	if !p.pingApp(r.Ctx(), app) {
+	err = p.pingApp(r.Ctx(), app)
+	if err != nil {
 		return nil, "", errors.Wrapf(err, "failed to install, %s path is not accessible", apps.DefaultPing.Path)
 	}
 	r.Log.Debugf("app install flow: app is pingable")

--- a/server/proxy/invoke_static.go
+++ b/server/proxy/invoke_static.go
@@ -59,17 +59,22 @@ func (p *Proxy) getStatic(r *incoming.Request, app *apps.App, path string) (io.R
 // pingApp checks if the app is accessible. Call its ping path with nothing
 // expanded, ignore 404 errors coming back and consider everything else a
 // "success".
-func (p *Proxy) pingApp(ctx context.Context, app *apps.App) (reachable bool) {
+func (p *Proxy) pingApp(ctx context.Context, app *apps.App) error {
 	ctx, cancel := context.WithTimeout(ctx, pingAppTimeout)
 	defer cancel()
 
 	up, err := p.upstreamForApp(app)
 	if err != nil {
-		return false
+		return errors.Wrap(err, "failed to get upstream for app")
 	}
 
 	_, err = upstream.Call(ctx, up, *app, apps.CallRequest{
 		Call: apps.DefaultPing,
 	})
-	return err == nil || errors.Cause(err) == utils.ErrNotFound
+
+	if err != nil && errors.Cause(err) != utils.ErrNotFound {
+		return errors.Wrapf(err, "failed to call %s endpoint", apps.DefaultPing.Path)
+	}
+
+	return nil
 }

--- a/server/proxy/list.go
+++ b/server/proxy/list.go
@@ -73,7 +73,7 @@ func (p *Proxy) PingInstalledApps(ctx context.Context) (installed []apps.App, re
 				// Builtin apps are always rechable
 				reachable = true
 			} else if !a.Disabled {
-				if p.pingApp(ctx, &a) {
+				if p.pingApp(ctx, &a) == nil {
 					reachable = true
 				}
 			}


### PR DESCRIPTION
#### Summary
Propagate any errors from `/ping` to the end user to make debugging easier.

#### Ticket Link
Part of https://mattermost.atlassian.net/browse/MM-49992