### PR TITLE
[MM-50054] Fix panic on server with invalid configuration

### DIFF
--- a/server/config/service.go
+++ b/server/config/service.go
@@ -52,7 +52,7 @@ type service struct {
 	mattermostConfig *model.Config
 }
 
-func MakeService(mm *pluginapi.Client, pliginManifest model.Manifest, botUserID string, telemetry *telemetry.Telemetry, i18nBundle *i18n.Bundle) (Service, utils.Logger, error) {
+func MakeService(mm *pluginapi.Client, pliginManifest model.Manifest, botUserID string, telemetry *telemetry.Telemetry, i18nBundle *i18n.Bundle, log utils.Logger) (Service, error) {
 	s := &service{
 		pluginManifest: pliginManifest,
 		botUserID:      botUserID,
@@ -65,19 +65,19 @@ func MakeService(mm *pluginapi.Client, pliginManifest model.Manifest, botUserID 
 	sc := StoredConfig{}
 	err := s.mm.Configuration.LoadPluginConfiguration(&sc)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	clone, log, err := s.newInitializedConfig(sc)
+	clone, err := s.newInitializedConfig(sc, log)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	s.lock.Lock()
 	s.conf = clone
 	s.lock.Unlock()
 
-	return s, log, nil
+	return s, nil
 }
 
 func (s *service) newConfig() Config {
@@ -90,8 +90,7 @@ func (s *service) newConfig() Config {
 	}
 }
 
-func (s *service) newInitializedConfig(newStoredConfig StoredConfig) (*Config, utils.Logger, error) {
-	log := s.NewBaseLogger()
+func (s *service) newInitializedConfig(newStoredConfig StoredConfig, log utils.Logger) (*Config, error) {
 	conf := s.newConfig()
 	conf.StoredConfig = newStoredConfig
 	newMattermostConfig := s.reloadMattermostConfig()
@@ -104,11 +103,11 @@ func (s *service) newInitializedConfig(newStoredConfig StoredConfig) (*Config, u
 
 	mattermostSiteURL := newMattermostConfig.ServiceSettings.SiteURL
 	if mattermostSiteURL == nil {
-		return nil, nil, errors.New("plugin requires Mattermost Site URL to be set")
+		return nil, errors.New("plugin requires Mattermost Site URL to be set")
 	}
 	u, err := url.Parse(*mattermostSiteURL)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "invalid SiteURL in config")
+		return nil, errors.Wrap(err, "invalid SiteURL in config")
 	}
 
 	var localURL string
@@ -119,11 +118,11 @@ func (s *service) newInitializedConfig(newStoredConfig StoredConfig) (*Config, u
 		// Avoid the reverse proxy by using the local port
 		listenAddress := newMattermostConfig.ServiceSettings.ListenAddress
 		if listenAddress == nil {
-			return nil, nil, errors.New("plugin requires Mattermost Listen Address to be set")
+			return nil, errors.New("plugin requires Mattermost Listen Address to be set")
 		}
 		host, port, err := net.SplitHostPort(*listenAddress)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 
 		if host == "" {
@@ -172,7 +171,7 @@ func (s *service) newInitializedConfig(newStoredConfig StoredConfig) (*Config, u
 			conf.AWSSecretKey = legacySecretKey
 		}
 		if conf.AWSAccessKey == "" || conf.AWSSecretKey == "" {
-			return nil, nil, errors.New("access credentials for AWS must be set in Mattermost Cloud mode")
+			return nil, errors.New("access credentials for AWS must be set in Mattermost Cloud mode")
 		}
 	}
 
@@ -182,7 +181,7 @@ func (s *service) newInitializedConfig(newStoredConfig StoredConfig) (*Config, u
 		conf.AllowHTTPApps = !conf.MattermostCloudMode || conf.DeveloperMode
 	}
 
-	return &conf, log, nil
+	return &conf, nil
 }
 
 func (s *service) Get() Config {
@@ -247,8 +246,15 @@ func (s *service) getMattermostLicense(log utils.Logger) *model.License {
 }
 
 func (s *service) Reconfigure(newStoredConfig StoredConfig, verbose bool, services ...Configurable) error {
-	// Use the old settings to log the processing of the new config.
-	clone, log, err := s.newInitializedConfig(newStoredConfig)
+	var log utils.Logger
+	if verbose {
+		// Use the old settings to log the processing of the new config.
+		log = s.NewBaseLogger()
+	} else {
+		log = utils.NilLogger{}
+	}
+
+	clone, err := s.newInitializedConfig(newStoredConfig, log)
 	if err != nil {
 		return err
 	}
@@ -257,9 +263,6 @@ func (s *service) Reconfigure(newStoredConfig StoredConfig, verbose bool, servic
 	s.conf = clone
 	s.lock.Unlock()
 
-	if !verbose {
-		log = utils.NilLogger{}
-	}
 	for _, service := range services {
 		if err := service.Configure(*clone, log); err != nil {
 			return errors.Wrapf(err, "failed to configure service %T", service)

--- a/server/config/service.go
+++ b/server/config/service.go
@@ -272,8 +272,12 @@ func (s *service) Reconfigure(newStoredConfig StoredConfig, verbose bool, servic
 }
 
 func (s *service) StoreConfig(sc StoredConfig, log utils.Logger) error {
-	log.Debugf("Storing configuration, %v installed , %v listed apps, developer mode %v, allow http apps %v",
-		len(sc.InstalledApps), len(sc.LocalManifests), sc.DeveloperModeOverride, sc.AllowHTTPAppsOverride)
+	log.Debugf("Storing configuration: %d installed, %d listed apps, developer mode %t, allow http apps %t",
+		len(sc.InstalledApps),
+		len(sc.LocalManifests),
+		sc.DeveloperModeOverride != nil && *sc.DeveloperModeOverride,
+		sc.AllowHTTPAppsOverride != nil && *sc.AllowHTTPAppsOverride,
+	)
 
 	// Refresh computed values immediately, do not wait for OnConfigurationChanged
 	err := s.Reconfigure(sc, false)

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -80,7 +80,7 @@ func (p *Plugin) OnActivate() (err error) {
 	p.tracker = telemetry.NewTelemetry(nil)
 
 	// Configure the plugin.
-	confService, log, err := config.MakeService(mm, p.manifest, botUserID, p.tracker, i18nBundle)
+	confService, err := config.MakeService(mm, p.manifest, botUserID, p.tracker, i18nBundle, log)
 	if err != nil {
 		log.WithError(err).Infow("failed to load initial configuration")
 		return errors.Wrap(err, "failed to load initial configuration")

--- a/server/plugin_test.go
+++ b/server/plugin_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost-plugin-apps/server/config"
+	"github.com/mattermost/mattermost-plugin-apps/utils"
 )
 
 func TestOnActivate(t *testing.T) {
@@ -90,7 +91,7 @@ func TestOnDeactivate(t *testing.T) {
 
 	mm := pluginapi.NewClient(p.API, p.Driver)
 	var err error
-	p.conf, _, err = config.MakeService(mm, manifest, "the_bot_id", nil, i18nBundle)
+	p.conf, err = config.MakeService(mm, manifest, "the_bot_id", nil, i18nBundle, utils.NilLogger{})
 	require.NoError(t, err)
 
 	testAPI.On("PublishWebSocketEvent", "plugin_disabled", map[string]interface{}{"version": manifest.Version}, &model.WebsocketBroadcast{})


### PR DESCRIPTION
#### Summary
If the server config is invalid, e.g. because `SITE_URL` is not set, the logger returned from `config.MakeService` is `nil`. In that case, the plugin logger should be used instead.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-50054
