### PR TITLE
fix rudder key secret name and remove wrong env mapping

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -15,7 +15,6 @@ on:
 env:
   TERM: xterm
   GO_VERSION: 1.19.6
-  MM_RUDDER_WRITE_KEY: ${{ secrets.MM_PLUGIN_APPS_RUDDER_WRITE_KEY }}
 
 jobs:
   build:

--- a/build/custom.mk
+++ b/build/custom.mk
@@ -1,11 +1,13 @@
 # Include custome targets and environment variables here
 default: all
 
-ifndef MM_RUDDER_WRITE_KEY
-    MM_RUDDER_WRITE_KEY = 1d5bMvdrfWClLxgK1FvV3s4U1tg
+# If there's no MM_RUDDER_PLUGINS_PROD, add DEV data
+RUDDER_WRITE_KEY = 1d5bMvdrfWClLxgK1FvV3s4U1tg
+ifdef MM_RUDDER_PLUGINS_PROD
+	RUDDER_WRITE_KEY = $(MM_RUDDER_PLUGINS_PROD)
 endif
 
-LDFLAGS += -X "github.com/mattermost/mattermost-plugin-api/experimental/telemetry.rudderWriteKey=$(MM_RUDDER_WRITE_KEY)"
+LDFLAGS += -X "github.com/mattermost/mattermost-plugin-api/experimental/telemetry.rudderWriteKey=$(RUDDER_WRITE_KEY)"
 
 BUILD_DATE = $(shell date -u)
 BUILD_HASH = $(shell git rev-parse HEAD)


### PR DESCRIPTION
#### Summary
After some name changing, MM_RUDDER_WRITE_KEY has become MM_RUDDER_PLUGINS_PROD.

Fix custom.mk so we get the right data.

Additionally, the variable mapping in the build workflow has been removed.

#### Ticket Link
no