### PR TITLE
Remove reference to prod rudder key in ci workflow, keep in cd workflow

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -15,6 +15,7 @@ on:
 env:
   TERM: xterm
   GO_VERSION: 1.19.6
+  MM_RUDDER_PLUGINS_PROD:  ${{ secrets.MM_RUDDER_PLUGINS_PROD }}
 
 jobs:
   build:

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -15,7 +15,7 @@ on:
 env:
   TERM: xterm
   GO_VERSION: 1.19.6
-  MM_RUDDER_PLUGINS_PROD:  ${{ secrets.MM_RUDDER_PLUGINS_PROD }}
+  MM_RUDDER_PLUGINS_PROD: ${{ secrets.MM_RUDDER_PLUGINS_PROD }}
 
 jobs:
   build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,6 @@ env:
   TERM: xterm
   GO_VERSION: 1.19.6
   NODE_VERSION: 16.15.0
-  MM_RUDDER_WRITE_KEY: ${{ secrets.MM_PLUGIN_APPS_RUDDER_WRITE_KEY }}
 
 jobs:
   lint:


### PR DESCRIPTION
#### Summary

Using the prod Rudderstack telemetry key in CI can skew our telemetry numbers. The production builds of the plugin produced by the `cd.yml` should still contain the prod key. This PR We makes it so we use the development key instead for the `ci.yml` workflow.

## Ticket Link

Fixes https://github.com/mattermost/mattermost-plugin-apps/issues/469