### PR TITLE
[MM-51931] Don't send channel_created event for DMs

### DIFF
--- a/server/proxy/notify.go
+++ b/server/proxy/notify.go
@@ -195,6 +195,12 @@ func (p *Proxy) NotifyUserTeam(member *model.TeamMember, actor *model.User, join
 // NotifyChannelCreated handles plugin's ChannelHasBeenCreated callback. It emits
 // "channel_created" notifications to subscribed apps.
 func (p *Proxy) NotifyChannelCreated(teamID, channelID string) {
+	// If the newly created channel is a DM, there is no teamID.
+	// Do not notify apps in this case.
+	if teamID == "" {
+		return
+	}
+
 	p.notifyAll(
 		apps.Event{
 			Subject: apps.SubjectChannelCreated,

--- a/server/store/subscriptions.go
+++ b/server/store/subscriptions.go
@@ -83,7 +83,7 @@ func subsKey(e apps.Event) (string, error) {
 func (s subscriptionStore) Get(e apps.Event) ([]Subscription, error) {
 	key, err := subsKey(e)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to generate event key")
 	}
 
 	stored := &StoredSubscriptions{}


### PR DESCRIPTION
#### Summary
If a newly created channel is a DM, the `ChannelHasBeenCreated` hook gets called with an empty `TeamID`. This leads to an error down the stack. Now, `ChannelHasBeenCreated` gets ignored for DMs.

I did try adding a test, but the only symptom of the bug is a log message (https://github.com/mattermost/mattermost-plugin-apps/blob/22741daa176f919160193831d3bd2f113aa369c8/server/proxy/notify.go#L225-L229) which is hard to test for.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-51931

