### PR TITLE
Release v1.2.2

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -4,8 +4,8 @@
     "description": "This plugin powers the Mattermost Apps Framework and is required for any Apps to run",
     "homepage_url": "https://developers.mattermost.com/integrate/apps",
     "support_url": "https://github.com/mattermost/mattermost-plugin-apps/issues",
-    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-apps/releases/tag/v1.2.1",
-    "version": "1.2.1",
+    "release_notes_url": "https://github.com/mattermost/mattermost-plugin-apps/releases/tag/v1.2.2",
+    "version": "1.2.2",
     "min_server_version": "7.7.0",
     "server": {
         "executables": {


### PR DESCRIPTION
#### Ticket Link
The release only contains two fixes:
- https://github.com/mattermost/mattermost-plugin-apps/pull/468
- https://github.com/mattermost/mattermost-plugin-apps/pull/472


The diff between v1.2.1 and v1.2.2 is https://github.com/mattermost/mattermost-plugin-apps/compare/v1.2.1...release-1.2.
