### PR TITLE
[MM-58505] Fix group channel expand

### DIFF
--- a/server/proxy/expand.go
+++ b/server/proxy/expand.go
@@ -488,7 +488,7 @@ func (e *expander) consistencyCheck() error {
 	}
 
 	if e.ExpandedContext.Channel != nil {
-		if e.UserAgentContext.TeamID != "" && e.ExpandedContext.Channel.Type != model.ChannelTypeDirect && e.ExpandedContext.Channel.TeamId != e.UserAgentContext.TeamID {
+		if e.UserAgentContext.TeamID != "" && e.ExpandedContext.Channel.Type != model.ChannelTypeDirect && e.ExpandedContext.Channel.Type != model.ChannelTypeGroup && e.ExpandedContext.Channel.TeamId != e.UserAgentContext.TeamID {
 			return errors.Errorf("expanded channel's team ID %s is different from user agent context %s",
 				e.ExpandedContext.Channel.TeamId, e.UserAgentContext.TeamID)
 		}


### PR DESCRIPTION

#### Summary

Having `channel: summary` in the expand section of an app (using app framework) make it unusable in the context of a group channel with the error message

```
failed to expand context: failed post-expand consistency check: expanded channel's team ID  is different from user agent context 1ntjrqrqdjy8mffhoc44g1e9zr
```

This is because, like Direct channels, the Group channel type has no TeamID so the consistency check fail and the expand fail, preventing from firing the application call.

This pull request fixes that behavior by ignoring Group Channels on the TeamID consistency check

#### Ticket Link

Fixes mattermost/mattermost#27271 and JIRA [MM-58505](https://mattermost.atlassian.net/browse/MM-58505)